### PR TITLE
Update package.json exports to have a commonJS require path

### DIFF
--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -26,7 +26,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish package
-        run: mvn -P release --batch-mode deploy -DskipTests
+        run: mvn -P central --batch-mode deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Move to Java Folder
+        run: cd java
+
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -29,7 +29,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish package
-        run: mvn -P central --batch-mode deploy -DskipTests
+        run: cd java && mvn -P central --batch-mode deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -1,0 +1,33 @@
+name: Java Release to Maven
+
+# on:
+#   push:
+#     tags:
+#       - "v*"
+on:
+  push:
+    branches: update-package-json-require
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_SIGNING_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Publish package
+        run: mvn -P release --batch-mode deploy -DskipTests
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -29,7 +29,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Publish package
-        run: cd java && mvn -P central --batch-mode deploy -DskipTests
+        run: cd java && mvn -P release --batch-mode deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -1,12 +1,9 @@
 name: Java Release to Maven
 
-# on:
-#   push:
-#     tags:
-#       - "v*"
 on:
   push:
-    branches: update-package-json-require
+    tags:
+      - "v*"
 
 jobs:
   publish:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -251,6 +251,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
         </plugins>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>kanmon-sdk</artifactId>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <url>https://github.com/Kanmon/sdk.git</url>
     <description>Kanmon API SDK</description>
     <scm>

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kanmon/sdk",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Kanmon API client",
   "author": "Kanmon",
   "repository": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -18,6 +18,7 @@
   "module": "./dist/index.js",
   "exports": {
     ".": {
+      "require": "./dist/index.js",
       "import": "./dist/index.js",
       "types": "./dist/index.d.js"
     }


### PR DESCRIPTION
SDK wasn't able to be required in CommonJS without this. Adds more compatibility / access.

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in .../node_modules/@kanmon/sdk/package.json
```