### PR TITLE
Make all SDKs proprietary (ENG-4121)

### DIFF
--- a/java/license.txt
+++ b/java/license.txt
@@ -1,0 +1,31 @@
+Kanmon Proprietary License
+
+Copyright © 2026 Kanmon Inc. All rights reserved.
+
+This software and all associated files, documentation, and materials
+(collectively, the "Software") are the proprietary and confidential property
+of Kanmon Inc. ("Kanmon") and are protected by copyright and other
+intellectual property laws.
+
+The Software is licensed, not sold. Subject to a valid agreement between you
+and Kanmon, Kanmon grants you a limited, non-exclusive, non-transferable,
+non-sublicensable, revocable license to use the Software solely to integrate
+with and access Kanmon's services in accordance with Kanmon's documentation
+and any applicable agreement between you and Kanmon.
+
+Except as expressly permitted by Kanmon in writing, you may not: (a) copy,
+modify, adapt, or create derivative works of the Software; (b) distribute,
+sell, lease, rent, sublicense, or otherwise transfer the Software to any
+third party; (c) reverse engineer, decompile, or disassemble the Software,
+or attempt to derive its source code, except to the extent such restriction
+is prohibited by applicable law; or (d) remove, obscure, or alter any
+proprietary notices contained in the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL
+KANMON BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For licensing inquiries, contact Kanmon Inc. at https://kanmon.com.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>kanmon-sdk</artifactId>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
-    <version>3.2.0</version>
+    <version>3.2.2</version>
     <url>https://github.com/Kanmon/sdk.git</url>
     <description>Kanmon API SDK</description>
     <scm>
@@ -27,8 +27,8 @@
     </developers>
     <licenses>
         <license>
-            <name>MIT License</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <name>Proprietary</name>
+            <comments>Kanmon Proprietary License. Copyright (c) Kanmon Inc. All rights reserved. See license.txt.</comments>
         </license>
     </licenses>
     <build>

--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,31 @@
+Kanmon Proprietary License
+
+Copyright © 2026 Kanmon Inc. All rights reserved.
+
+This software and all associated files, documentation, and materials
+(collectively, the "Software") are the proprietary and confidential property
+of Kanmon Inc. ("Kanmon") and are protected by copyright and other
+intellectual property laws.
+
+The Software is licensed, not sold. Subject to a valid agreement between you
+and Kanmon, Kanmon grants you a limited, non-exclusive, non-transferable,
+non-sublicensable, revocable license to use the Software solely to integrate
+with and access Kanmon's services in accordance with Kanmon's documentation
+and any applicable agreement between you and Kanmon.
+
+Except as expressly permitted by Kanmon in writing, you may not: (a) copy,
+modify, adapt, or create derivative works of the Software; (b) distribute,
+sell, lease, rent, sublicense, or otherwise transfer the Software to any
+third party; (c) reverse engineer, decompile, or disassemble the Software,
+or attempt to derive its source code, except to the extent such restriction
+is prohibited by applicable law; or (d) remove, obscure, or alter any
+proprietary notices contained in the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL
+KANMON BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For licensing inquiries, contact Kanmon Inc. at https://kanmon.com.

--- a/openapitools.json
+++ b/openapitools.json
@@ -33,7 +33,8 @@
           "openApiNullable": true,
           "library": "okhttp-gson",
           "serializationLibrary": "gson",
-          "hideGenerationTimestamp": true
+          "hideGenerationTimestamp": true,
+          "licenseName": "Proprietary"
         },
         "ignoreFileOverride": "#{cwd}/ignore_file_overrides/.openapi-java-generator-ignore"
       }

--- a/ts/license.txt
+++ b/ts/license.txt
@@ -1,0 +1,31 @@
+Kanmon Proprietary License
+
+Copyright © 2026 Kanmon Inc. All rights reserved.
+
+This software and all associated files, documentation, and materials
+(collectively, the "Software") are the proprietary and confidential property
+of Kanmon Inc. ("Kanmon") and are protected by copyright and other
+intellectual property laws.
+
+The Software is licensed, not sold. Subject to a valid agreement between you
+and Kanmon, Kanmon grants you a limited, non-exclusive, non-transferable,
+non-sublicensable, revocable license to use the Software solely to integrate
+with and access Kanmon's services in accordance with Kanmon's documentation
+and any applicable agreement between you and Kanmon.
+
+Except as expressly permitted by Kanmon in writing, you may not: (a) copy,
+modify, adapt, or create derivative works of the Software; (b) distribute,
+sell, lease, rent, sublicense, or otherwise transfer the Software to any
+third party; (c) reverse engineer, decompile, or disassemble the Software,
+or attempt to derive its source code, except to the extent such restriction
+is prohibited by applicable law; or (d) remove, obscure, or alter any
+proprietary notices contained in the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL
+KANMON BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For licensing inquiries, contact Kanmon Inc. at https://kanmon.com.

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kanmon/sdk",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Kanmon API client",
   "author": "Kanmon",
   "repository": {
@@ -12,7 +12,7 @@
     "sdk",
     "typescript"
   ],
-  "license": "MIT",
+  "license": "SEE LICENSE IN license.txt",
   "main": "./dist/index.js",
   "type": "commonjs",
   "module": "./dist/index.js",
@@ -25,7 +25,8 @@
   },
   "typings": "./dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "license.txt"
   ],
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
## Summary
Updates the licensing of both SDKs (TypeScript and Java) from MIT to a Kanmon Proprietary License, as flagged by Avalara. (ENG-4121)

## Changes
- **license.txt** added in 3 locations (identical content): repo root, `ts/`, and `java/`. The `ts/license.txt` ships in the npm package.
- **ts/package.json**: `license` MIT -> `SEE LICENSE IN license.txt`; version `3.2.1` -> `3.2.2`; added `license.txt` to the `files` array.
- **java/pom.xml**: `<licenses>` block MIT -> Proprietary; project version `3.2.0` -> `3.2.2`.
- **openapitools.json**: added `"licenseName": "Proprietary"` to the `java` generator's `additionalProperties` so regeneration stays consistent.

## Not in scope
- gradle/sbt versions left at 1.0.0 as-is per request.
- No generated source files modified.
- Publishing, git tagging, and GitHub Release creation will be handled by the team and are NOT part of this PR.