### PR TITLE
Update latest api and upgrade sdk versions

### DIFF
--- a/java/.openapi-generator/FILES
+++ b/java/.openapi-generator/FILES
@@ -162,6 +162,7 @@ src/main/java/com/kanmon/client/model/PrimaryBusinessOwnerAlreadyExistsForBusine
 src/main/java/com/kanmon/client/model/PrimaryBusinessOwnerAlreadyExistsWithEmailException.java
 src/main/java/com/kanmon/client/model/PrimaryBusinessOwnerNotFoundException.java
 src/main/java/com/kanmon/client/model/ProductType.java
+src/main/java/com/kanmon/client/model/RepaymentCadence.java
 src/main/java/com/kanmon/client/model/SessionInvoice.java
 src/main/java/com/kanmon/client/model/SessionInvoiceWithInvoiceFile.java
 src/main/java/com/kanmon/client/model/SomeOffersHaveExpiredException.java
@@ -176,4 +177,5 @@ src/main/java/com/kanmon/client/model/User.java
 src/main/java/com/kanmon/client/model/UserAlreadyExistsWithEmailException.java
 src/main/java/com/kanmon/client/model/UserAlreadyExistsWithPlatformUserIdException.java
 src/main/java/com/kanmon/client/model/UserNotFoundException.java
-src/test/java/com/kanmon/client/model/LoanStatusTest.java
+src/test/java/com/kanmon/client/api/SandboxUtilitiesApiTest.java
+src/test/java/com/kanmon/client/api/UsersApiTest.java

--- a/java/api/openapi.yaml
+++ b/java/api/openapi.yaml
@@ -1,8 +1,17 @@
 openapi: 3.0.0
 info:
   contact: {}
-  description: Kanmon's public api. Contains all of the endpoints for both capital
-    providers and platforms
+  description: |-
+    Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.
+
+    ## Rate limiting
+
+    Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:
+
+    - `X-RateLimit-Limit` — maximum requests allowed per minute.
+    - `X-RateLimit-Remaining` — requests remaining in the current window.
+
+    When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
   title: Kanmon Public V2 API
   version: 2.0.0
 servers:
@@ -87,6 +96,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ForbiddenException'
           description: ForbiddenException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -188,6 +213,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ForbiddenException'
           description: ForbiddenException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -248,6 +289,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/BusinessAlreadyExistsException'
           description: BusinessAlreadyExistsException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -319,6 +376,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/BusinessNotFoundException'
           description: BusinessNotFoundException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -400,6 +473,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/BusinessAlreadyExistsException'
           description: BusinessAlreadyExistsException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -511,6 +600,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/BusinessNotFoundException'
           description: BusinessNotFoundException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -565,13 +670,24 @@ paths:
         style: form
       - description: A comma delimited list of your Kanmon’s unique business IDs for
           users.
-        example: "767d9894-7214-4a0a-9c4e-ec4a7c70c1e1,e7935095-6ea8-44d9-a5b5-6235a61dc1cf"
+        example: "d6fb9273-f9c7-4c87-98ed-9a25fc667815,2a124938-fa43-4861-af81-b262c87f9bc4"
         explode: true
         in: query
         name: businessIds
         required: false
         schema:
           type: string
+        style: form
+      - description: "When true, secondary owners are included in results alongside\
+          \ other users. When false, secondary owners are excluded from results. Defaults\
+          \ to `false`."
+        example: false
+        explode: true
+        in: query
+        name: includeSecondaryOwners
+        required: false
+        schema:
+          type: boolean
         style: form
       - description: The number of records to skip when performing pagination. Defaults
           to `0`.
@@ -632,6 +748,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ForbiddenException'
           description: ForbiddenException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -692,6 +824,22 @@ paths:
                 $ref: '#/components/schemas/createUser_409_response'
           description: "PrimaryBusinessOwnerAlreadyExistsForBusinessException, UserAlreadyExistsWithPlatformUserIdException,\
             \ UserAlreadyExistsWithEmailException"
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -764,6 +912,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserNotFoundException'
           description: UserNotFoundException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -846,6 +1010,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/updateUser_409_response'
           description: "UserAlreadyExistsWithEmailException, PrimaryBusinessOwnerAlreadyExistsForBusinessException"
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -910,6 +1090,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/PrimaryBusinessOwnerAlreadyExistsForBusinessException'
           description: PrimaryBusinessOwnerAlreadyExistsForBusinessException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -969,6 +1165,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserNotFoundException'
           description: UserNotFoundException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -1042,6 +1254,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/getInvoice_404_response'
           description: "InvoiceNotFoundException, BusinessNotFoundException"
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -1169,6 +1397,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ForbiddenException'
           description: ForbiddenException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -1213,8 +1457,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/financeInvoice_400_response'
-          description: "PlatformInvoiceIdAlreadyExistsException, InvoicePaymentPlanNotFoundException,\
-            \ InvalidInvoiceDueDateException, \n        IncorrectFinancingAmountException"
+          description: |-
+            PlatformInvoiceIdAlreadyExistsException, InvoicePaymentPlanNotFoundException, InvalidInvoiceDueDateException,
+                    IncorrectFinancingAmountException
         "403":
           content:
             application/json:
@@ -1234,6 +1479,22 @@ paths:
                 $ref: '#/components/schemas/financeInvoice_409_response'
           description: "IssuedProductStatusNotCurrentException, IncorrectProductTypeException,\
             \ InsufficientCreditLimitException"
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -1292,6 +1553,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/OfferNotFoundException'
           description: OfferNotFoundException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -1401,6 +1678,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ForbiddenException'
           description: ForbiddenException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -1458,6 +1751,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/IssuedProductNotFoundException'
           description: IssuedProductNotFoundException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -1577,6 +1886,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ForbiddenException'
           description: ForbiddenException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -1633,7 +1958,7 @@ paths:
         style: form
       - description: A comma delimited list of your Kanmon’s unique business IDs for
           bannk accounts.
-        example: "7d632bf1-8537-4c93-bc4a-f485a789f95e,1f05fd2d-2140-41c4-b294-5e0b0196cb6f"
+        example: "4376bbac-7e0d-4e9a-9c34-a231effbee26,7fc8f162-c95c-4e11-af88-5e4aef993bf1"
         explode: true
         in: query
         name: businessIds
@@ -1700,6 +2025,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ForbiddenException'
           description: ForbiddenException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -1763,6 +2104,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/BankAccountAlreadyExistException'
           description: BankAccountAlreadyExistException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -1837,6 +2194,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/BankAccountNotFoundException'
           description: BankAccountNotFoundException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -1917,6 +2290,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/BankAccountNotFoundException'
           description: BankAccountNotFoundException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -1976,6 +2365,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaymentOrderNotFoundException'
           description: PaymentOrderNotFoundException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -2000,7 +2405,7 @@ paths:
       operationId: getPaymentScheduleForAIssuedProduct
       parameters:
       - description: A comma delimited list of Kanmon’s unique draw request IDs.
-        example: "95dbeab9-f94f-460d-85b8-a50b7bb0b136,782ec087-24f5-40d9-91d4-d005b7d06c14"
+        example: "358ff585-7021-4d03-bf63-9446a1506e59,03e3c306-6257-4edf-804f-8cc46b0148f9"
         explode: true
         in: query
         name: drawRequestIds
@@ -2101,6 +2506,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/IssuedProductNotFoundException'
           description: IssuedProductNotFoundException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -2159,6 +2580,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/DrawRequestNotFoundException'
           description: ""
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -2278,6 +2715,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ForbiddenException'
           description: ForbiddenException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -2327,6 +2780,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ForbiddenException'
           description: ForbiddenException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -2439,6 +2908,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ForbiddenException'
           description: ForbiddenException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -2499,6 +2984,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/createIntegratedMcaReceivable_409_response'
           description: "IncorrectProductTypeException, IntegratedMcaReceivableAlreadyExistsException"
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -2564,6 +3065,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/BusinessHasNoIntegratedMcaProductException'
           description: BusinessHasNoIntegratedMcaProductException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -2629,6 +3146,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ForbiddenException'
           description: ForbiddenException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -2676,6 +3209,8 @@ paths:
           type: string
         style: form
       responses:
+        "204":
+          description: ""
         "400":
           content:
             application/json:
@@ -2688,6 +3223,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/ForbiddenException'
           description: ForbiddenException
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -2752,6 +3303,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/createEmbeddedSession_409_response'
           description: "BusinessHasNoInvoiceFinancingProductException, PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException"
+        "429":
+          description: Too Many Requests. Returned when rate limiting applies to this
+            platform and the request limit has been exceeded.
+          headers:
+            X-RateLimit-Limit:
+              description: Maximum number of requests allowed per minute.
+              explode: false
+              schema:
+                type: integer
+              style: simple
+            X-RateLimit-Remaining:
+              description: Number of remaining requests available.
+              explode: false
+              schema:
+                type: integer
+              style: simple
         "500":
           content:
             application/json:
@@ -3542,12 +4109,14 @@ components:
             \ offers, sign financing agreements, and service an active issued product.\
             \ <br/><br/>An operator is a user with permission to service an active\
             \ issued product. Examples are uploading invoices on behalf of the business,\
-            \ checking the status of payments, etc. <br /><br/>Please note Kanmon\
-            \ supports an additional user role called secondary owners. Secondary\
-            \ owners are beneficial owners of a business, like primary owners, and\
-            \ Kanmon must perform KYC checks for these users. Kanmon will handle creating\
-            \ and managing these users for KYC purposes through a separate process.\
-            \ <br/>"
+            \ checking the status of payments, etc. <br /><br/>A secondary owner is\
+            \ a beneficial owner of the business who must complete KYC. This means\
+            \ the user can sign financing agreements when required and service an\
+            \ active issued product. During onboarding, the primary owner invites\
+            \ secondary owners. Secondary owners are directed to a separate Kanmon-hosted\
+            \ page where they complete onboarding, sign legal documents, and KYC.\
+            \ They can also access servicing from that page. Kanmon sends a `USER.CREATED`\
+            \ webhook when a secondary owner is created."
           example:
           - PRIMARY_OWNER
           items:
@@ -3597,6 +4166,7 @@ components:
         platformUserId:
           description: Your platform’s unique ID for the user.
           example: "12345"
+          nullable: true
           type: string
         platformBusinessId:
           description: Your platform’s unique business ID for the user.
@@ -3641,25 +4211,27 @@ components:
           nullable: true
           type: string
         roles:
-          description: "The user’s roles. If no roles are defined, the user will be\
-            \ prompted to select a role within Kanmon. <br/><br/>A primary owner is\
-            \ a user with the authority to issue debt on behalf of the business. This\
-            \ means the user can complete onboarding, receive offers, choose to accept\
-            \ offers, sign financing agreements, and service an active issued product.\
-            \ <br/><br/>An operator is a user with permission to service an active\
-            \ issued product. Examples are uploading invoices on behalf of the business,\
-            \ checking the status of payments, etc. <br /><br/>Please note Kanmon\
-            \ supports an additional user role called secondary owners. Secondary\
-            \ owners are beneficial owners of a business, like primary owners, and\
-            \ Kanmon must perform KYC checks for these users. Kanmon will handle creating\
-            \ and managing these users for KYC purposes through a separate process.\
-            \ <br/>"
+          description: "The user’s roles. <br/><br/>A primary owner is a user with\
+            \ the authority to issue debt on behalf of the business. This means the\
+            \ user can complete onboarding, receive offers, choose to accept offers,\
+            \ sign financing agreements, and service an active issued product. <br/><br/>An\
+            \ operator is a user with permission to service an active issued product.\
+            \ Examples are uploading invoices on behalf of the business, checking\
+            \ the status of payments, etc. <br /><br/>A secondary owner is a beneficial\
+            \ owner of the business who must complete KYC. This means the user can\
+            \ sign financing agreements when required and service an active issued\
+            \ product. During onboarding, the primary owner invites secondary owners.\
+            \ Secondary owners are directed to a separate Kanmon-hosted page where\
+            \ they complete onboarding, sign legal documents, and KYC. They can also\
+            \ access servicing from that page. Kanmon sends a `USER.CREATED` webhook\
+            \ when a secondary owner is created."
           example:
           - PRIMARY_OWNER
           items:
             enum:
             - PRIMARY_OWNER
             - OPERATOR
+            - SECONDARY_OWNER
             type: string
           type: array
         metadata:
@@ -3824,18 +4396,20 @@ components:
             \ offers, sign financing agreements, and service an active issued product.\
             \ <br/><br/>An operator is a user with permission to service an active\
             \ issued product. Examples are uploading invoices on behalf of the business,\
-            \ checking the status of payments, etc. <br /><br/>Please note Kanmon\
-            \ supports an additional user role called secondary owners. Secondary\
-            \ owners are beneficial owners of a business, like primary owners, and\
-            \ Kanmon must perform KYC checks for these users. Kanmon will handle creating\
-            \ and managing these users for KYC purposes through a separate process.\
-            \ <br/>"
+            \ checking the status of payments, etc. <br /><br/>A secondary owner is\
+            \ a beneficial owner of the business who must complete KYC. This means\
+            \ the user can sign financing agreements when required and service an\
+            \ active issued product. During onboarding, the primary owner invites\
+            \ secondary owners. Secondary owners are directed to a separate Kanmon-hosted\
+            \ page where they complete onboarding, sign legal documents, and KYC.\
+            \ They can also access servicing from that page. Kanmon sends a `USER.CREATED`\
+            \ webhook when a secondary owner is created."
           example:
           - PRIMARY_OWNER
           items:
             enum:
-            - OPERATOR
             - PRIMARY_OWNER
+            - OPERATOR
             type: string
           type: array
         metadata:
@@ -4815,6 +5389,11 @@ components:
       - repaymentPercentage
       - totalRepaymentCents
       type: object
+    RepaymentCadence:
+      enum:
+      - WEEKLY
+      - MONTHLY
+      type: string
     LineOfCreditOfferTerms:
       properties:
         productType:
@@ -4834,13 +5413,29 @@ components:
           example: 2
           type: number
         repaymentDurationMonths:
-          description: The duration of the repayment for each draw - in months.
+          deprecated: true
+          description: "The duration of the repayment for each draw - in months. Deprecated:\
+            \ use `numPaymentPeriods` and `repaymentCadence` instead."
+          example: 3
+          type: number
+        repaymentCadence:
+          $ref: '#/components/schemas/RepaymentCadence'
+        gracePeriodDays:
+          description: The number of days after each draw during which no installment
+            payments are due. Interest still accrues.
+          example: 30
+          type: number
+        numPaymentPeriods:
+          description: The number of installment payment periods for each draw.
           example: 3
           type: number
       required:
       - feePercentage
+      - gracePeriodDays
       - interestRatePercentage
+      - numPaymentPeriods
       - productType
+      - repaymentCadence
       - repaymentDurationMonths
       - totalLimitCents
       type: object
@@ -5242,14 +5837,30 @@ components:
           example: 2
           type: number
         repaymentDurationMonths:
-          description: The duration of the repayment for each draw - in months.
+          deprecated: true
+          description: "The duration of the repayment for each draw - in months. Deprecated:\
+            \ use `numPaymentPeriods` and `repaymentCadence` instead."
+          example: 3
+          type: number
+        repaymentCadence:
+          $ref: '#/components/schemas/RepaymentCadence'
+        gracePeriodDays:
+          description: The number of days after each draw during which no installment
+            payments are due. Interest still accrues.
+          example: 30
+          type: number
+        numPaymentPeriods:
+          description: The number of installment payment periods for each draw.
           example: 3
           type: number
       required:
       - availableLimitCents
       - feePercentage
+      - gracePeriodDays
       - interestRatePercentage
+      - numPaymentPeriods
       - productType
+      - repaymentCadence
       - repaymentDurationMonths
       - totalLimitCents
       type: object
@@ -5895,16 +6506,20 @@ components:
       type: string
     DrawRequest:
       example:
-        createdAt: 2022-06-01T03:57:26.115Z
-        amountCents: 1000000
+        gracePeriodDays: 30
+        remainingBalanceCents: 500000
         feePercentage: 5
         issuedProductId: 2b5d0f14-9b73-4f44-a82a-2182a9ff77bb
         disbursementAmountCents: 960000
+        createdAt: 2022-06-01T03:57:26.115Z
+        amountCents: 1000000
+        repaymentCadence: WEEKLY
         id: adbcccf9-3a7f-4040-add3-55c9d6da2d37
         feeAmountCents: 40000
         interestRatePercentage: 10
         repaymentDurationMonths: 6
         status: DRAW_REQUEST_CREATED
+        numPaymentPeriods: 3
         updatedAt: 2022-06-01T03:57:26.115Z
       properties:
         id:
@@ -5941,8 +6556,26 @@ components:
           example: 5
           type: number
         repaymentDurationMonths:
-          description: The duration of the repayment for the draw request - in months.
+          deprecated: true
+          description: "The duration of the repayment for the draw request - in months.\
+            \ Deprecated: use `numPaymentPeriods` and `repaymentCadence` instead."
           example: 6
+          type: number
+        repaymentCadence:
+          $ref: '#/components/schemas/RepaymentCadence'
+        gracePeriodDays:
+          description: The number of days after the draw during which no installment
+            payments are due. Interest still accrues.
+          example: 30
+          type: number
+        numPaymentPeriods:
+          description: The number of installment payment periods for the draw request.
+          example: 3
+          type: number
+        remainingBalanceCents:
+          description: The outstanding principal balance on the draw request - in
+            cents. Equal to the original draw amount minus confirmed principal repayments.
+          example: 500000
           type: number
         createdAt:
           description: Creation UTC ISO 8601 timestamp of the draw request.
@@ -5958,9 +6591,13 @@ components:
       - disbursementAmountCents
       - feeAmountCents
       - feePercentage
+      - gracePeriodDays
       - id
       - interestRatePercentage
       - issuedProductId
+      - numPaymentPeriods
+      - remainingBalanceCents
+      - repaymentCadence
       - repaymentDurationMonths
       - status
       - updatedAt
@@ -5992,27 +6629,35 @@ components:
     GetDrawRequestsResponse:
       example:
         drawRequests:
-        - createdAt: 2022-06-01T03:57:26.115Z
-          amountCents: 1000000
+        - gracePeriodDays: 30
+          remainingBalanceCents: 500000
           feePercentage: 5
           issuedProductId: 2b5d0f14-9b73-4f44-a82a-2182a9ff77bb
           disbursementAmountCents: 960000
+          createdAt: 2022-06-01T03:57:26.115Z
+          amountCents: 1000000
+          repaymentCadence: WEEKLY
           id: adbcccf9-3a7f-4040-add3-55c9d6da2d37
           feeAmountCents: 40000
           interestRatePercentage: 10
           repaymentDurationMonths: 6
           status: DRAW_REQUEST_CREATED
+          numPaymentPeriods: 3
           updatedAt: 2022-06-01T03:57:26.115Z
-        - createdAt: 2022-06-01T03:57:26.115Z
-          amountCents: 1000000
+        - gracePeriodDays: 30
+          remainingBalanceCents: 500000
           feePercentage: 5
           issuedProductId: 2b5d0f14-9b73-4f44-a82a-2182a9ff77bb
           disbursementAmountCents: 960000
+          createdAt: 2022-06-01T03:57:26.115Z
+          amountCents: 1000000
+          repaymentCadence: WEEKLY
           id: adbcccf9-3a7f-4040-add3-55c9d6da2d37
           feeAmountCents: 40000
           interestRatePercentage: 10
           repaymentDurationMonths: 6
           status: DRAW_REQUEST_CREATED
+          numPaymentPeriods: 3
           updatedAt: 2022-06-01T03:57:26.115Z
         pagination: ""
       properties:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>kanmon-sdk</artifactId>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
-    <version>3.2.2</version>
+    <version>4.0.0</version>
     <url>https://github.com/Kanmon/sdk.git</url>
     <description>Kanmon API SDK</description>
     <scm>

--- a/java/src/main/java/com/kanmon/client/ApiCallback.java
+++ b/java/src/main/java/com/kanmon/client/ApiCallback.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/ApiClient.java
+++ b/java/src/main/java/com/kanmon/client/ApiClient.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/ApiException.java
+++ b/java/src/main/java/com/kanmon/client/ApiException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/ApiResponse.java
+++ b/java/src/main/java/com/kanmon/client/ApiResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/Configuration.java
+++ b/java/src/main/java/com/kanmon/client/Configuration.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/GzipRequestInterceptor.java
+++ b/java/src/main/java/com/kanmon/client/GzipRequestInterceptor.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/JSON.java
+++ b/java/src/main/java/com/kanmon/client/JSON.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/Pair.java
+++ b/java/src/main/java/com/kanmon/client/Pair.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/ProgressRequestBody.java
+++ b/java/src/main/java/com/kanmon/client/ProgressRequestBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/ProgressResponseBody.java
+++ b/java/src/main/java/com/kanmon/client/ProgressResponseBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/ServerConfiguration.java
+++ b/java/src/main/java/com/kanmon/client/ServerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/ServerVariable.java
+++ b/java/src/main/java/com/kanmon/client/ServerVariable.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/StringUtil.java
+++ b/java/src/main/java/com/kanmon/client/StringUtil.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/api/BankAccountsApi.java
+++ b/java/src/main/java/com/kanmon/client/api/BankAccountsApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -96,6 +96,7 @@ public class BankAccountsApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BankAccountAlreadyExistException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -169,6 +170,7 @@ public class BankAccountsApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BankAccountAlreadyExistException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -191,6 +193,7 @@ public class BankAccountsApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BankAccountAlreadyExistException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -215,6 +218,7 @@ public class BankAccountsApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BankAccountAlreadyExistException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -244,6 +248,7 @@ public class BankAccountsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -348,6 +353,7 @@ public class BankAccountsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -375,6 +381,7 @@ public class BankAccountsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -404,6 +411,7 @@ public class BankAccountsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -428,6 +436,7 @@ public class BankAccountsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BankAccountNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -505,6 +514,7 @@ public class BankAccountsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BankAccountNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -527,6 +537,7 @@ public class BankAccountsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BankAccountNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -551,6 +562,7 @@ public class BankAccountsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BankAccountNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -576,6 +588,7 @@ public class BankAccountsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BankAccountNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -660,6 +673,7 @@ public class BankAccountsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BankAccountNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -683,6 +697,7 @@ public class BankAccountsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BankAccountNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -708,6 +723,7 @@ public class BankAccountsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BankAccountNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/BusinessesApi.java
+++ b/java/src/main/java/com/kanmon/client/api/BusinessesApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -97,6 +97,7 @@ public class BusinessesApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException, CustomInitializationNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessAlreadyExistsException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -170,6 +171,7 @@ public class BusinessesApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException, CustomInitializationNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessAlreadyExistsException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -192,6 +194,7 @@ public class BusinessesApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException, CustomInitializationNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessAlreadyExistsException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -216,6 +219,7 @@ public class BusinessesApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException, CustomInitializationNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessAlreadyExistsException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -243,6 +247,7 @@ public class BusinessesApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -337,6 +342,7 @@ public class BusinessesApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -362,6 +368,7 @@ public class BusinessesApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -389,6 +396,7 @@ public class BusinessesApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -413,6 +421,7 @@ public class BusinessesApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -490,6 +499,7 @@ public class BusinessesApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -512,6 +522,7 @@ public class BusinessesApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -536,6 +547,7 @@ public class BusinessesApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -564,6 +576,7 @@ public class BusinessesApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -661,6 +674,7 @@ public class BusinessesApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -687,6 +701,7 @@ public class BusinessesApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -715,6 +730,7 @@ public class BusinessesApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -741,6 +757,7 @@ public class BusinessesApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException, CustomInitializationNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessAlreadyExistsException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -826,6 +843,7 @@ public class BusinessesApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException, CustomInitializationNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessAlreadyExistsException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -850,6 +868,7 @@ public class BusinessesApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException, CustomInitializationNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessAlreadyExistsException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -876,6 +895,7 @@ public class BusinessesApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException, CustomInitializationNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessAlreadyExistsException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/ConnectTokensApi.java
+++ b/java/src/main/java/com/kanmon/client/api/ConnectTokensApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -90,6 +90,7 @@ public class ConnectTokensApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> UserNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -162,6 +163,7 @@ public class ConnectTokensApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> UserNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -183,6 +185,7 @@ public class ConnectTokensApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> UserNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -206,6 +209,7 @@ public class ConnectTokensApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> UserNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/DocumentsApi.java
+++ b/java/src/main/java/com/kanmon/client/api/DocumentsApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -90,6 +90,7 @@ public class DocumentsApi {
         <tr><td> 201 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -175,6 +176,7 @@ public class DocumentsApi {
         <tr><td> 201 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -197,6 +199,7 @@ public class DocumentsApi {
         <tr><td> 201 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -221,6 +224,7 @@ public class DocumentsApi {
         <tr><td> 201 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/DrawRequestsApi.java
+++ b/java/src/main/java/com/kanmon/client/api/DrawRequestsApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -97,6 +97,7 @@ public class DrawRequestsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -201,6 +202,7 @@ public class DrawRequestsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -228,6 +230,7 @@ public class DrawRequestsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -257,6 +260,7 @@ public class DrawRequestsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -280,6 +284,7 @@ public class DrawRequestsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td>  </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -352,6 +357,7 @@ public class DrawRequestsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td>  </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -373,6 +379,7 @@ public class DrawRequestsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td>  </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -396,6 +403,7 @@ public class DrawRequestsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td>  </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/EmbeddedSessionsApi.java
+++ b/java/src/main/java/com/kanmon/client/api/EmbeddedSessionsApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -92,6 +92,7 @@ public class EmbeddedSessionsApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessHasNoInvoiceFinancingProductException, PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -165,6 +166,7 @@ public class EmbeddedSessionsApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessHasNoInvoiceFinancingProductException, PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -187,6 +189,7 @@ public class EmbeddedSessionsApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessHasNoInvoiceFinancingProductException, PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -211,6 +214,7 @@ public class EmbeddedSessionsApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessHasNoInvoiceFinancingProductException, PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/IntegratedMcaApi.java
+++ b/java/src/main/java/com/kanmon/client/api/IntegratedMcaApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -97,6 +97,7 @@ public class IntegratedMcaApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> IncorrectProductTypeException, IntegratedMcaReceivableAlreadyExistsException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -170,6 +171,7 @@ public class IntegratedMcaApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> IncorrectProductTypeException, IntegratedMcaReceivableAlreadyExistsException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -192,6 +194,7 @@ public class IntegratedMcaApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> IncorrectProductTypeException, IntegratedMcaReceivableAlreadyExistsException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -216,6 +219,7 @@ public class IntegratedMcaApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> IncorrectProductTypeException, IntegratedMcaReceivableAlreadyExistsException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -240,6 +244,7 @@ public class IntegratedMcaApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessHasNoIntegratedMcaProductException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -313,6 +318,7 @@ public class IntegratedMcaApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessHasNoIntegratedMcaProductException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -335,6 +341,7 @@ public class IntegratedMcaApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessHasNoIntegratedMcaProductException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -359,6 +366,7 @@ public class IntegratedMcaApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> BusinessHasNoIntegratedMcaProductException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -387,6 +395,7 @@ public class IntegratedMcaApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -486,6 +495,7 @@ public class IntegratedMcaApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -512,6 +522,7 @@ public class IntegratedMcaApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -540,6 +551,7 @@ public class IntegratedMcaApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/InvoicesApi.java
+++ b/java/src/main/java/com/kanmon/client/api/InvoicesApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -92,10 +92,11 @@ public class InvoicesApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 201 </td><td> Invoice financed successfully </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> PlatformInvoiceIdAlreadyExistsException, InvoicePaymentPlanNotFoundException, InvalidInvoiceDueDateException,          IncorrectFinancingAmountException </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> PlatformInvoiceIdAlreadyExistsException, InvoicePaymentPlanNotFoundException, InvalidInvoiceDueDateException,         IncorrectFinancingAmountException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException, InvoicePaymentPlanNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> IssuedProductStatusNotCurrentException, IncorrectProductTypeException, InsufficientCreditLimitException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -165,10 +166,11 @@ public class InvoicesApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 201 </td><td> Invoice financed successfully </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> PlatformInvoiceIdAlreadyExistsException, InvoicePaymentPlanNotFoundException, InvalidInvoiceDueDateException,          IncorrectFinancingAmountException </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> PlatformInvoiceIdAlreadyExistsException, InvoicePaymentPlanNotFoundException, InvalidInvoiceDueDateException,         IncorrectFinancingAmountException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException, InvoicePaymentPlanNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> IssuedProductStatusNotCurrentException, IncorrectProductTypeException, InsufficientCreditLimitException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -187,10 +189,11 @@ public class InvoicesApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 201 </td><td> Invoice financed successfully </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> PlatformInvoiceIdAlreadyExistsException, InvoicePaymentPlanNotFoundException, InvalidInvoiceDueDateException,          IncorrectFinancingAmountException </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> PlatformInvoiceIdAlreadyExistsException, InvoicePaymentPlanNotFoundException, InvalidInvoiceDueDateException,         IncorrectFinancingAmountException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException, InvoicePaymentPlanNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> IssuedProductStatusNotCurrentException, IncorrectProductTypeException, InsufficientCreditLimitException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -211,10 +214,11 @@ public class InvoicesApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 201 </td><td> Invoice financed successfully </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> PlatformInvoiceIdAlreadyExistsException, InvoicePaymentPlanNotFoundException, InvalidInvoiceDueDateException,          IncorrectFinancingAmountException </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> PlatformInvoiceIdAlreadyExistsException, InvoicePaymentPlanNotFoundException, InvalidInvoiceDueDateException,         IncorrectFinancingAmountException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException, InvoicePaymentPlanNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> IssuedProductStatusNotCurrentException, IncorrectProductTypeException, InsufficientCreditLimitException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -245,6 +249,7 @@ public class InvoicesApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -354,6 +359,7 @@ public class InvoicesApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -382,6 +388,7 @@ public class InvoicesApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -412,6 +419,7 @@ public class InvoicesApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -436,6 +444,7 @@ public class InvoicesApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> InvoiceNotFoundException, BusinessNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -513,6 +522,7 @@ public class InvoicesApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> InvoiceNotFoundException, BusinessNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -535,6 +545,7 @@ public class InvoicesApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> InvoiceNotFoundException, BusinessNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -559,6 +570,7 @@ public class InvoicesApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> InvoiceNotFoundException, BusinessNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/IssuedProductsApi.java
+++ b/java/src/main/java/com/kanmon/client/api/IssuedProductsApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -97,6 +97,7 @@ public class IssuedProductsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -201,6 +202,7 @@ public class IssuedProductsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -228,6 +230,7 @@ public class IssuedProductsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -257,6 +260,7 @@ public class IssuedProductsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -280,6 +284,7 @@ public class IssuedProductsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -352,6 +357,7 @@ public class IssuedProductsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -373,6 +379,7 @@ public class IssuedProductsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -396,6 +403,7 @@ public class IssuedProductsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/OffersApi.java
+++ b/java/src/main/java/com/kanmon/client/api/OffersApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -96,6 +96,7 @@ public class OffersApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -195,6 +196,7 @@ public class OffersApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -221,6 +223,7 @@ public class OffersApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -249,6 +252,7 @@ public class OffersApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -272,6 +276,7 @@ public class OffersApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> OfferNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -344,6 +349,7 @@ public class OffersApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> OfferNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -365,6 +371,7 @@ public class OffersApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> OfferNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -388,6 +395,7 @@ public class OffersApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> OfferNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/PaymentsApi.java
+++ b/java/src/main/java/com/kanmon/client/api/PaymentsApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -93,6 +93,7 @@ public class PaymentsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> PaymentOrderNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -165,6 +166,7 @@ public class PaymentsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> PaymentOrderNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -186,6 +188,7 @@ public class PaymentsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> PaymentOrderNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -209,6 +212,7 @@ public class PaymentsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> PaymentOrderNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -239,6 +243,7 @@ public class PaymentsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -346,6 +351,7 @@ public class PaymentsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -374,6 +380,7 @@ public class PaymentsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -404,6 +411,7 @@ public class PaymentsApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> IssuedProductNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/PrequalificationsApi.java
+++ b/java/src/main/java/com/kanmon/client/api/PrequalificationsApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -92,6 +92,7 @@ public class PrequalificationsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -181,6 +182,7 @@ public class PrequalificationsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -205,6 +207,7 @@ public class PrequalificationsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -231,6 +234,7 @@ public class PrequalificationsApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/SandboxUtilitiesApi.java
+++ b/java/src/main/java/com/kanmon/client/api/SandboxUtilitiesApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -85,8 +85,10 @@ public class SandboxUtilitiesApi {
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 204 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -159,8 +161,10 @@ public class SandboxUtilitiesApi {
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 204 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -178,8 +182,10 @@ public class SandboxUtilitiesApi {
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 204 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -199,8 +205,10 @@ public class SandboxUtilitiesApi {
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 204 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -223,6 +231,7 @@ public class SandboxUtilitiesApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -299,6 +308,7 @@ public class SandboxUtilitiesApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -320,6 +330,7 @@ public class SandboxUtilitiesApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -343,6 +354,7 @@ public class SandboxUtilitiesApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/api/UsersApi.java
+++ b/java/src/main/java/com/kanmon/client/api/UsersApi.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -100,6 +100,7 @@ public class UsersApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> PrimaryBusinessOwnerAlreadyExistsForBusinessException, UserAlreadyExistsWithPlatformUserIdException, UserAlreadyExistsWithEmailException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -173,6 +174,7 @@ public class UsersApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> PrimaryBusinessOwnerAlreadyExistsForBusinessException, UserAlreadyExistsWithPlatformUserIdException, UserAlreadyExistsWithEmailException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -195,6 +197,7 @@ public class UsersApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> PrimaryBusinessOwnerAlreadyExistsForBusinessException, UserAlreadyExistsWithPlatformUserIdException, UserAlreadyExistsWithEmailException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -219,6 +222,7 @@ public class UsersApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> PrimaryBusinessOwnerAlreadyExistsForBusinessException, UserAlreadyExistsWithPlatformUserIdException, UserAlreadyExistsWithEmailException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -235,6 +239,7 @@ public class UsersApi {
      * @param platformUserIds A comma delimited list of your platform’s unique IDs for users. (optional)
      * @param platformBusinessIds A comma delimited list of your platform’s unique business IDs for users. (optional)
      * @param businessIds A comma delimited list of your Kanmon’s unique business IDs for users. (optional)
+     * @param includeSecondaryOwners When true, secondary owners are included in results alongside other users. When false, secondary owners are excluded from results. Defaults to &#x60;false&#x60;. (optional)
      * @param offset The number of records to skip when performing pagination. Defaults to &#x60;0&#x60;. (optional)
      * @param limit The number of records to limit when performing pagination. Defaults to &#x60;100&#x60;, which is the max. (optional)
      * @param createdAtStart Filter for records where &#x60;createdAt&#x60; is greater than or equal to this value. ISO 8601 format. (optional)
@@ -248,10 +253,11 @@ public class UsersApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getAllUsersCall(String ids, String platformUserIds, String platformBusinessIds, String businessIds, BigDecimal offset, BigDecimal limit, String createdAtStart, String createdAtEnd, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getAllUsersCall(String ids, String platformUserIds, String platformBusinessIds, String businessIds, Boolean includeSecondaryOwners, BigDecimal offset, BigDecimal limit, String createdAtStart, String createdAtEnd, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -292,6 +298,10 @@ public class UsersApi {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("businessIds", businessIds));
         }
 
+        if (includeSecondaryOwners != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("includeSecondaryOwners", includeSecondaryOwners));
+        }
+
         if (offset != null) {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("offset", offset));
         }
@@ -328,8 +338,8 @@ public class UsersApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getAllUsersValidateBeforeCall(String ids, String platformUserIds, String platformBusinessIds, String businessIds, BigDecimal offset, BigDecimal limit, String createdAtStart, String createdAtEnd, final ApiCallback _callback) throws ApiException {
-        return getAllUsersCall(ids, platformUserIds, platformBusinessIds, businessIds, offset, limit, createdAtStart, createdAtEnd, _callback);
+    private okhttp3.Call getAllUsersValidateBeforeCall(String ids, String platformUserIds, String platformBusinessIds, String businessIds, Boolean includeSecondaryOwners, BigDecimal offset, BigDecimal limit, String createdAtStart, String createdAtEnd, final ApiCallback _callback) throws ApiException {
+        return getAllUsersCall(ids, platformUserIds, platformBusinessIds, businessIds, includeSecondaryOwners, offset, limit, createdAtStart, createdAtEnd, _callback);
 
     }
 
@@ -340,6 +350,7 @@ public class UsersApi {
      * @param platformUserIds A comma delimited list of your platform’s unique IDs for users. (optional)
      * @param platformBusinessIds A comma delimited list of your platform’s unique business IDs for users. (optional)
      * @param businessIds A comma delimited list of your Kanmon’s unique business IDs for users. (optional)
+     * @param includeSecondaryOwners When true, secondary owners are included in results alongside other users. When false, secondary owners are excluded from results. Defaults to &#x60;false&#x60;. (optional)
      * @param offset The number of records to skip when performing pagination. Defaults to &#x60;0&#x60;. (optional)
      * @param limit The number of records to limit when performing pagination. Defaults to &#x60;100&#x60;, which is the max. (optional)
      * @param createdAtStart Filter for records where &#x60;createdAt&#x60; is greater than or equal to this value. ISO 8601 format. (optional)
@@ -352,11 +363,12 @@ public class UsersApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
-    public GetUsersResponse getAllUsers(String ids, String platformUserIds, String platformBusinessIds, String businessIds, BigDecimal offset, BigDecimal limit, String createdAtStart, String createdAtEnd) throws ApiException {
-        ApiResponse<GetUsersResponse> localVarResp = getAllUsersWithHttpInfo(ids, platformUserIds, platformBusinessIds, businessIds, offset, limit, createdAtStart, createdAtEnd);
+    public GetUsersResponse getAllUsers(String ids, String platformUserIds, String platformBusinessIds, String businessIds, Boolean includeSecondaryOwners, BigDecimal offset, BigDecimal limit, String createdAtStart, String createdAtEnd) throws ApiException {
+        ApiResponse<GetUsersResponse> localVarResp = getAllUsersWithHttpInfo(ids, platformUserIds, platformBusinessIds, businessIds, includeSecondaryOwners, offset, limit, createdAtStart, createdAtEnd);
         return localVarResp.getData();
     }
 
@@ -367,6 +379,7 @@ public class UsersApi {
      * @param platformUserIds A comma delimited list of your platform’s unique IDs for users. (optional)
      * @param platformBusinessIds A comma delimited list of your platform’s unique business IDs for users. (optional)
      * @param businessIds A comma delimited list of your Kanmon’s unique business IDs for users. (optional)
+     * @param includeSecondaryOwners When true, secondary owners are included in results alongside other users. When false, secondary owners are excluded from results. Defaults to &#x60;false&#x60;. (optional)
      * @param offset The number of records to skip when performing pagination. Defaults to &#x60;0&#x60;. (optional)
      * @param limit The number of records to limit when performing pagination. Defaults to &#x60;100&#x60;, which is the max. (optional)
      * @param createdAtStart Filter for records where &#x60;createdAt&#x60; is greater than or equal to this value. ISO 8601 format. (optional)
@@ -379,11 +392,12 @@ public class UsersApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<GetUsersResponse> getAllUsersWithHttpInfo(String ids, String platformUserIds, String platformBusinessIds, String businessIds, BigDecimal offset, BigDecimal limit, String createdAtStart, String createdAtEnd) throws ApiException {
-        okhttp3.Call localVarCall = getAllUsersValidateBeforeCall(ids, platformUserIds, platformBusinessIds, businessIds, offset, limit, createdAtStart, createdAtEnd, null);
+    public ApiResponse<GetUsersResponse> getAllUsersWithHttpInfo(String ids, String platformUserIds, String platformBusinessIds, String businessIds, Boolean includeSecondaryOwners, BigDecimal offset, BigDecimal limit, String createdAtStart, String createdAtEnd) throws ApiException {
+        okhttp3.Call localVarCall = getAllUsersValidateBeforeCall(ids, platformUserIds, platformBusinessIds, businessIds, includeSecondaryOwners, offset, limit, createdAtStart, createdAtEnd, null);
         Type localVarReturnType = new TypeToken<GetUsersResponse>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -395,6 +409,7 @@ public class UsersApi {
      * @param platformUserIds A comma delimited list of your platform’s unique IDs for users. (optional)
      * @param platformBusinessIds A comma delimited list of your platform’s unique business IDs for users. (optional)
      * @param businessIds A comma delimited list of your Kanmon’s unique business IDs for users. (optional)
+     * @param includeSecondaryOwners When true, secondary owners are included in results alongside other users. When false, secondary owners are excluded from results. Defaults to &#x60;false&#x60;. (optional)
      * @param offset The number of records to skip when performing pagination. Defaults to &#x60;0&#x60;. (optional)
      * @param limit The number of records to limit when performing pagination. Defaults to &#x60;100&#x60;, which is the max. (optional)
      * @param createdAtStart Filter for records where &#x60;createdAt&#x60; is greater than or equal to this value. ISO 8601 format. (optional)
@@ -408,12 +423,13 @@ public class UsersApi {
         <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getAllUsersAsync(String ids, String platformUserIds, String platformBusinessIds, String businessIds, BigDecimal offset, BigDecimal limit, String createdAtStart, String createdAtEnd, final ApiCallback<GetUsersResponse> _callback) throws ApiException {
+    public okhttp3.Call getAllUsersAsync(String ids, String platformUserIds, String platformBusinessIds, String businessIds, Boolean includeSecondaryOwners, BigDecimal offset, BigDecimal limit, String createdAtStart, String createdAtEnd, final ApiCallback<GetUsersResponse> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getAllUsersValidateBeforeCall(ids, platformUserIds, platformBusinessIds, businessIds, offset, limit, createdAtStart, createdAtEnd, _callback);
+        okhttp3.Call localVarCall = getAllUsersValidateBeforeCall(ids, platformUserIds, platformBusinessIds, businessIds, includeSecondaryOwners, offset, limit, createdAtStart, createdAtEnd, _callback);
         Type localVarReturnType = new TypeToken<GetUsersResponse>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
@@ -432,6 +448,7 @@ public class UsersApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> UserNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -509,6 +526,7 @@ public class UsersApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> UserNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -531,6 +549,7 @@ public class UsersApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> UserNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -555,6 +574,7 @@ public class UsersApi {
         <tr><td> 400 </td><td> BadRequestException </td><td>  -  </td></tr>
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> UserNotFoundException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -579,6 +599,7 @@ public class UsersApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> PrimaryBusinessOwnerAlreadyExistsForBusinessException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -652,6 +673,7 @@ public class UsersApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> PrimaryBusinessOwnerAlreadyExistsForBusinessException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -674,6 +696,7 @@ public class UsersApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> PrimaryBusinessOwnerAlreadyExistsForBusinessException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -698,6 +721,7 @@ public class UsersApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> BusinessNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> PrimaryBusinessOwnerAlreadyExistsForBusinessException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -724,6 +748,7 @@ public class UsersApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> UserNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> UserAlreadyExistsWithEmailException, PrimaryBusinessOwnerAlreadyExistsForBusinessException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -809,6 +834,7 @@ public class UsersApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> UserNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> UserAlreadyExistsWithEmailException, PrimaryBusinessOwnerAlreadyExistsForBusinessException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -833,6 +859,7 @@ public class UsersApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> UserNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> UserAlreadyExistsWithEmailException, PrimaryBusinessOwnerAlreadyExistsForBusinessException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */
@@ -859,6 +886,7 @@ public class UsersApi {
         <tr><td> 403 </td><td> ForbiddenException </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> UserNotFoundException </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> UserAlreadyExistsWithEmailException, PrimaryBusinessOwnerAlreadyExistsForBusinessException </td><td>  -  </td></tr>
+        <tr><td> 429 </td><td> Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded. </td><td>  * X-RateLimit-Limit - Maximum number of requests allowed per minute. <br>  * X-RateLimit-Remaining - Number of remaining requests available. <br>  </td></tr>
         <tr><td> 500 </td><td> InternalServerErrorException </td><td>  -  </td></tr>
      </table>
      */

--- a/java/src/main/java/com/kanmon/client/auth/ApiKeyAuth.java
+++ b/java/src/main/java/com/kanmon/client/auth/ApiKeyAuth.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/auth/HttpBasicAuth.java
+++ b/java/src/main/java/com/kanmon/client/auth/HttpBasicAuth.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/auth/HttpBearerAuth.java
+++ b/java/src/main/java/com/kanmon/client/auth/HttpBearerAuth.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/AbstractOpenApiSchema.java
+++ b/java/src/main/java/com/kanmon/client/model/AbstractOpenApiSchema.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/AccountsPayableFinancingOfferTerms.java
+++ b/java/src/main/java/com/kanmon/client/model/AccountsPayableFinancingOfferTerms.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -134,6 +134,50 @@ public class AccountsPayableFinancingOfferTerms {
     this.pricingPlans = pricingPlans;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the AccountsPayableFinancingOfferTerms instance itself
+   */
+  public AccountsPayableFinancingOfferTerms putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -147,12 +191,13 @@ public class AccountsPayableFinancingOfferTerms {
     AccountsPayableFinancingOfferTerms accountsPayableFinancingOfferTerms = (AccountsPayableFinancingOfferTerms) o;
     return Objects.equals(this.productType, accountsPayableFinancingOfferTerms.productType) &&
         Objects.equals(this.totalLimitCents, accountsPayableFinancingOfferTerms.totalLimitCents) &&
-        Objects.equals(this.pricingPlans, accountsPayableFinancingOfferTerms.pricingPlans);
+        Objects.equals(this.pricingPlans, accountsPayableFinancingOfferTerms.pricingPlans)&&
+        Objects.equals(this.additionalProperties, accountsPayableFinancingOfferTerms.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productType, totalLimitCents, pricingPlans);
+    return Objects.hash(productType, totalLimitCents, pricingPlans, additionalProperties);
   }
 
   @Override
@@ -162,6 +207,7 @@ public class AccountsPayableFinancingOfferTerms {
     sb.append("    productType: ").append(toIndentedString(productType)).append("\n");
     sb.append("    totalLimitCents: ").append(toIndentedString(totalLimitCents)).append("\n");
     sb.append("    pricingPlans: ").append(toIndentedString(pricingPlans)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -208,14 +254,6 @@ public class AccountsPayableFinancingOfferTerms {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!AccountsPayableFinancingOfferTerms.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `AccountsPayableFinancingOfferTerms` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : AccountsPayableFinancingOfferTerms.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -252,6 +290,28 @@ public class AccountsPayableFinancingOfferTerms {
            @Override
            public void write(JsonWriter out, AccountsPayableFinancingOfferTerms value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -259,7 +319,28 @@ public class AccountsPayableFinancingOfferTerms {
            public AccountsPayableFinancingOfferTerms read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             AccountsPayableFinancingOfferTerms instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/AccountsPayableFinancingServicingData.java
+++ b/java/src/main/java/com/kanmon/client/model/AccountsPayableFinancingServicingData.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -157,6 +157,50 @@ public class AccountsPayableFinancingServicingData {
     this.availableLimitCents = availableLimitCents;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the AccountsPayableFinancingServicingData instance itself
+   */
+  public AccountsPayableFinancingServicingData putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -171,12 +215,13 @@ public class AccountsPayableFinancingServicingData {
     return Objects.equals(this.productType, accountsPayableFinancingServicingData.productType) &&
         Objects.equals(this.totalLimitCents, accountsPayableFinancingServicingData.totalLimitCents) &&
         Objects.equals(this.pricingPlans, accountsPayableFinancingServicingData.pricingPlans) &&
-        Objects.equals(this.availableLimitCents, accountsPayableFinancingServicingData.availableLimitCents);
+        Objects.equals(this.availableLimitCents, accountsPayableFinancingServicingData.availableLimitCents)&&
+        Objects.equals(this.additionalProperties, accountsPayableFinancingServicingData.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productType, totalLimitCents, pricingPlans, availableLimitCents);
+    return Objects.hash(productType, totalLimitCents, pricingPlans, availableLimitCents, additionalProperties);
   }
 
   @Override
@@ -187,6 +232,7 @@ public class AccountsPayableFinancingServicingData {
     sb.append("    totalLimitCents: ").append(toIndentedString(totalLimitCents)).append("\n");
     sb.append("    pricingPlans: ").append(toIndentedString(pricingPlans)).append("\n");
     sb.append("    availableLimitCents: ").append(toIndentedString(availableLimitCents)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -235,14 +281,6 @@ public class AccountsPayableFinancingServicingData {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!AccountsPayableFinancingServicingData.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `AccountsPayableFinancingServicingData` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : AccountsPayableFinancingServicingData.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -279,6 +317,28 @@ public class AccountsPayableFinancingServicingData {
            @Override
            public void write(JsonWriter out, AccountsPayableFinancingServicingData value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -286,7 +346,28 @@ public class AccountsPayableFinancingServicingData {
            public AccountsPayableFinancingServicingData read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             AccountsPayableFinancingServicingData instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/AccountsPayableInvoiceFlowSessionTokenData.java
+++ b/java/src/main/java/com/kanmon/client/model/AccountsPayableInvoiceFlowSessionTokenData.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -159,6 +159,50 @@ public class AccountsPayableInvoiceFlowSessionTokenData {
     this.invoices = invoices;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the AccountsPayableInvoiceFlowSessionTokenData instance itself
+   */
+  public AccountsPayableInvoiceFlowSessionTokenData putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -171,12 +215,13 @@ public class AccountsPayableInvoiceFlowSessionTokenData {
     }
     AccountsPayableInvoiceFlowSessionTokenData accountsPayableInvoiceFlowSessionTokenData = (AccountsPayableInvoiceFlowSessionTokenData) o;
     return Objects.equals(this.component, accountsPayableInvoiceFlowSessionTokenData.component) &&
-        Objects.equals(this.invoices, accountsPayableInvoiceFlowSessionTokenData.invoices);
+        Objects.equals(this.invoices, accountsPayableInvoiceFlowSessionTokenData.invoices)&&
+        Objects.equals(this.additionalProperties, accountsPayableInvoiceFlowSessionTokenData.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(component, invoices);
+    return Objects.hash(component, invoices, additionalProperties);
   }
 
   @Override
@@ -185,6 +230,7 @@ public class AccountsPayableInvoiceFlowSessionTokenData {
     sb.append("class AccountsPayableInvoiceFlowSessionTokenData {\n");
     sb.append("    component: ").append(toIndentedString(component)).append("\n");
     sb.append("    invoices: ").append(toIndentedString(invoices)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -229,14 +275,6 @@ public class AccountsPayableInvoiceFlowSessionTokenData {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!AccountsPayableInvoiceFlowSessionTokenData.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `AccountsPayableInvoiceFlowSessionTokenData` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : AccountsPayableInvoiceFlowSessionTokenData.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -276,6 +314,28 @@ public class AccountsPayableInvoiceFlowSessionTokenData {
            @Override
            public void write(JsonWriter out, AccountsPayableInvoiceFlowSessionTokenData value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -283,7 +343,28 @@ public class AccountsPayableInvoiceFlowSessionTokenData {
            public AccountsPayableInvoiceFlowSessionTokenData read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             AccountsPayableInvoiceFlowSessionTokenData instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData.java
+++ b/java/src/main/java/com/kanmon/client/model/AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -159,6 +159,50 @@ public class AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData {
     this.invoices = invoices;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData instance itself
+   */
+  public AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -171,12 +215,13 @@ public class AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData {
     }
     AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData accountsPayableInvoiceFlowWithInvoiceFileSessionTokenData = (AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData) o;
     return Objects.equals(this.component, accountsPayableInvoiceFlowWithInvoiceFileSessionTokenData.component) &&
-        Objects.equals(this.invoices, accountsPayableInvoiceFlowWithInvoiceFileSessionTokenData.invoices);
+        Objects.equals(this.invoices, accountsPayableInvoiceFlowWithInvoiceFileSessionTokenData.invoices)&&
+        Objects.equals(this.additionalProperties, accountsPayableInvoiceFlowWithInvoiceFileSessionTokenData.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(component, invoices);
+    return Objects.hash(component, invoices, additionalProperties);
   }
 
   @Override
@@ -185,6 +230,7 @@ public class AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData {
     sb.append("class AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData {\n");
     sb.append("    component: ").append(toIndentedString(component)).append("\n");
     sb.append("    invoices: ").append(toIndentedString(invoices)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -229,14 +275,6 @@ public class AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -276,6 +314,28 @@ public class AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData {
            @Override
            public void write(JsonWriter out, AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -283,7 +343,28 @@ public class AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData {
            public AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/AccountsPayableSessionInvoice.java
+++ b/java/src/main/java/com/kanmon/client/model/AccountsPayableSessionInvoice.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -405,6 +405,50 @@ public class AccountsPayableSessionInvoice {
     this.description = description;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the AccountsPayableSessionInvoice instance itself
+   */
+  public AccountsPayableSessionInvoice putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -428,12 +472,13 @@ public class AccountsPayableSessionInvoice {
         Objects.equals(this.payeeFirstName, accountsPayableSessionInvoice.payeeFirstName) &&
         Objects.equals(this.payeeMiddleName, accountsPayableSessionInvoice.payeeMiddleName) &&
         Objects.equals(this.payeeLastName, accountsPayableSessionInvoice.payeeLastName) &&
-        Objects.equals(this.description, accountsPayableSessionInvoice.description);
+        Objects.equals(this.description, accountsPayableSessionInvoice.description)&&
+        Objects.equals(this.additionalProperties, accountsPayableSessionInvoice.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(platformInvoiceId, platformInvoiceNumber, invoiceAmountCents, invoiceDueDate, invoiceIssuedDate, payeeEmail, payeeAddress, payeeType, payeeBusinessName, payeeFirstName, payeeMiddleName, payeeLastName, description);
+    return Objects.hash(platformInvoiceId, platformInvoiceNumber, invoiceAmountCents, invoiceDueDate, invoiceIssuedDate, payeeEmail, payeeAddress, payeeType, payeeBusinessName, payeeFirstName, payeeMiddleName, payeeLastName, description, additionalProperties);
   }
 
   @Override
@@ -453,6 +498,7 @@ public class AccountsPayableSessionInvoice {
     sb.append("    payeeMiddleName: ").append(toIndentedString(payeeMiddleName)).append("\n");
     sb.append("    payeeLastName: ").append(toIndentedString(payeeLastName)).append("\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -509,14 +555,6 @@ public class AccountsPayableSessionInvoice {
       if (jsonElement == null) {
         if (!AccountsPayableSessionInvoice.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
           throw new IllegalArgumentException(String.format("The required field(s) %s in AccountsPayableSessionInvoice is not found in the empty JSON string", AccountsPayableSessionInvoice.openapiRequiredFields.toString()));
-        }
-      }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!AccountsPayableSessionInvoice.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `AccountsPayableSessionInvoice` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
         }
       }
 
@@ -583,6 +621,28 @@ public class AccountsPayableSessionInvoice {
            @Override
            public void write(JsonWriter out, AccountsPayableSessionInvoice value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -590,7 +650,28 @@ public class AccountsPayableSessionInvoice {
            public AccountsPayableSessionInvoice read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             AccountsPayableSessionInvoice instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/AccountsPayableSessionInvoiceWithInvoiceFile.java
+++ b/java/src/main/java/com/kanmon/client/model/AccountsPayableSessionInvoiceWithInvoiceFile.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -428,6 +428,50 @@ public class AccountsPayableSessionInvoiceWithInvoiceFile {
     this.description = description;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the AccountsPayableSessionInvoiceWithInvoiceFile instance itself
+   */
+  public AccountsPayableSessionInvoiceWithInvoiceFile putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -452,12 +496,13 @@ public class AccountsPayableSessionInvoiceWithInvoiceFile {
         Objects.equals(this.payeeFirstName, accountsPayableSessionInvoiceWithInvoiceFile.payeeFirstName) &&
         Objects.equals(this.payeeMiddleName, accountsPayableSessionInvoiceWithInvoiceFile.payeeMiddleName) &&
         Objects.equals(this.payeeLastName, accountsPayableSessionInvoiceWithInvoiceFile.payeeLastName) &&
-        Objects.equals(this.description, accountsPayableSessionInvoiceWithInvoiceFile.description);
+        Objects.equals(this.description, accountsPayableSessionInvoiceWithInvoiceFile.description)&&
+        Objects.equals(this.additionalProperties, accountsPayableSessionInvoiceWithInvoiceFile.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(platformInvoiceId, documentId, platformInvoiceNumber, invoiceAmountCents, invoiceDueDate, invoiceIssuedDate, payeeEmail, payeeAddress, payeeType, payeeBusinessName, payeeFirstName, payeeMiddleName, payeeLastName, description);
+    return Objects.hash(platformInvoiceId, documentId, platformInvoiceNumber, invoiceAmountCents, invoiceDueDate, invoiceIssuedDate, payeeEmail, payeeAddress, payeeType, payeeBusinessName, payeeFirstName, payeeMiddleName, payeeLastName, description, additionalProperties);
   }
 
   @Override
@@ -478,6 +523,7 @@ public class AccountsPayableSessionInvoiceWithInvoiceFile {
     sb.append("    payeeMiddleName: ").append(toIndentedString(payeeMiddleName)).append("\n");
     sb.append("    payeeLastName: ").append(toIndentedString(payeeLastName)).append("\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -531,14 +577,6 @@ public class AccountsPayableSessionInvoiceWithInvoiceFile {
       if (jsonElement == null) {
         if (!AccountsPayableSessionInvoiceWithInvoiceFile.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
           throw new IllegalArgumentException(String.format("The required field(s) %s in AccountsPayableSessionInvoiceWithInvoiceFile is not found in the empty JSON string", AccountsPayableSessionInvoiceWithInvoiceFile.openapiRequiredFields.toString()));
-        }
-      }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!AccountsPayableSessionInvoiceWithInvoiceFile.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `AccountsPayableSessionInvoiceWithInvoiceFile` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
         }
       }
 
@@ -610,6 +648,28 @@ public class AccountsPayableSessionInvoiceWithInvoiceFile {
            @Override
            public void write(JsonWriter out, AccountsPayableSessionInvoiceWithInvoiceFile value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -617,7 +677,28 @@ public class AccountsPayableSessionInvoiceWithInvoiceFile {
            public AccountsPayableSessionInvoiceWithInvoiceFile read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             AccountsPayableSessionInvoiceWithInvoiceFile instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/ActivityLog.java
+++ b/java/src/main/java/com/kanmon/client/model/ActivityLog.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -213,6 +213,50 @@ public class ActivityLog {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the ActivityLog instance itself
+   */
+  public ActivityLog putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -230,12 +274,13 @@ public class ActivityLog {
         Objects.equals(this.payload, activityLog.payload) &&
         Objects.equals(this.eventType, activityLog.eventType) &&
         Objects.equals(this.createdAt, activityLog.createdAt) &&
-        Objects.equals(this.updatedAt, activityLog.updatedAt);
+        Objects.equals(this.updatedAt, activityLog.updatedAt)&&
+        Objects.equals(this.additionalProperties, activityLog.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, businessId, platformBusinessId, payload, eventType, createdAt, updatedAt);
+    return Objects.hash(id, businessId, platformBusinessId, payload, eventType, createdAt, updatedAt, additionalProperties);
   }
 
   @Override
@@ -249,6 +294,7 @@ public class ActivityLog {
     sb.append("    eventType: ").append(toIndentedString(eventType)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -303,14 +349,6 @@ public class ActivityLog {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!ActivityLog.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ActivityLog` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : ActivityLog.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -353,6 +391,28 @@ public class ActivityLog {
            @Override
            public void write(JsonWriter out, ActivityLog value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -360,7 +420,28 @@ public class ActivityLog {
            public ActivityLog read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             ActivityLog instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/Address.java
+++ b/java/src/main/java/com/kanmon/client/model/Address.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -353,6 +353,50 @@ public class Address {
     this.country = country;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the Address instance itself
+   */
+  public Address putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -369,7 +413,8 @@ public class Address {
         Objects.equals(this.city, address.city) &&
         Objects.equals(this.state, address.state) &&
         Objects.equals(this.zipcode, address.zipcode) &&
-        Objects.equals(this.country, address.country);
+        Objects.equals(this.country, address.country)&&
+        Objects.equals(this.additionalProperties, address.additionalProperties);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -378,7 +423,7 @@ public class Address {
 
   @Override
   public int hashCode() {
-    return Objects.hash(addressLineOne, addressLineTwo, city, state, zipcode, country);
+    return Objects.hash(addressLineOne, addressLineTwo, city, state, zipcode, country, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -398,6 +443,7 @@ public class Address {
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    zipcode: ").append(toIndentedString(zipcode)).append("\n");
     sb.append("    country: ").append(toIndentedString(country)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -449,14 +495,6 @@ public class Address {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!Address.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Address` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : Address.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -501,6 +539,28 @@ public class Address {
            @Override
            public void write(JsonWriter out, Address value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -508,7 +568,28 @@ public class Address {
            public Address read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             Address instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BadRequestException.java
+++ b/java/src/main/java/com/kanmon/client/model/BadRequestException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class BadRequestException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BadRequestException instance itself
+   */
+  public BadRequestException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class BadRequestException {
     BadRequestException badRequestException = (BadRequestException) o;
     return Objects.equals(this.errorCode, badRequestException.errorCode) &&
         Objects.equals(this.message, badRequestException.message) &&
-        Objects.equals(this.timestamp, badRequestException.timestamp);
+        Objects.equals(this.timestamp, badRequestException.timestamp)&&
+        Objects.equals(this.additionalProperties, badRequestException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class BadRequestException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class BadRequestException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BadRequestException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BadRequestException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BadRequestException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class BadRequestException {
            @Override
            public void write(JsonWriter out, BadRequestException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class BadRequestException {
            public BadRequestException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BadRequestException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BankAccountAlreadyExistException.java
+++ b/java/src/main/java/com/kanmon/client/model/BankAccountAlreadyExistException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class BankAccountAlreadyExistException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BankAccountAlreadyExistException instance itself
+   */
+  public BankAccountAlreadyExistException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class BankAccountAlreadyExistException {
     BankAccountAlreadyExistException bankAccountAlreadyExistException = (BankAccountAlreadyExistException) o;
     return Objects.equals(this.errorCode, bankAccountAlreadyExistException.errorCode) &&
         Objects.equals(this.message, bankAccountAlreadyExistException.message) &&
-        Objects.equals(this.timestamp, bankAccountAlreadyExistException.timestamp);
+        Objects.equals(this.timestamp, bankAccountAlreadyExistException.timestamp)&&
+        Objects.equals(this.additionalProperties, bankAccountAlreadyExistException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class BankAccountAlreadyExistException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class BankAccountAlreadyExistException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BankAccountAlreadyExistException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BankAccountAlreadyExistException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BankAccountAlreadyExistException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class BankAccountAlreadyExistException {
            @Override
            public void write(JsonWriter out, BankAccountAlreadyExistException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class BankAccountAlreadyExistException {
            public BankAccountAlreadyExistException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BankAccountAlreadyExistException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BankAccountNotFoundException.java
+++ b/java/src/main/java/com/kanmon/client/model/BankAccountNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class BankAccountNotFoundException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BankAccountNotFoundException instance itself
+   */
+  public BankAccountNotFoundException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class BankAccountNotFoundException {
     BankAccountNotFoundException bankAccountNotFoundException = (BankAccountNotFoundException) o;
     return Objects.equals(this.errorCode, bankAccountNotFoundException.errorCode) &&
         Objects.equals(this.message, bankAccountNotFoundException.message) &&
-        Objects.equals(this.timestamp, bankAccountNotFoundException.timestamp);
+        Objects.equals(this.timestamp, bankAccountNotFoundException.timestamp)&&
+        Objects.equals(this.additionalProperties, bankAccountNotFoundException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class BankAccountNotFoundException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class BankAccountNotFoundException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BankAccountNotFoundException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BankAccountNotFoundException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BankAccountNotFoundException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class BankAccountNotFoundException {
            @Override
            public void write(JsonWriter out, BankAccountNotFoundException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class BankAccountNotFoundException {
            public BankAccountNotFoundException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BankAccountNotFoundException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BankStatementsInvalidException.java
+++ b/java/src/main/java/com/kanmon/client/model/BankStatementsInvalidException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class BankStatementsInvalidException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BankStatementsInvalidException instance itself
+   */
+  public BankStatementsInvalidException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class BankStatementsInvalidException {
     BankStatementsInvalidException bankStatementsInvalidException = (BankStatementsInvalidException) o;
     return Objects.equals(this.errorCode, bankStatementsInvalidException.errorCode) &&
         Objects.equals(this.message, bankStatementsInvalidException.message) &&
-        Objects.equals(this.timestamp, bankStatementsInvalidException.timestamp);
+        Objects.equals(this.timestamp, bankStatementsInvalidException.timestamp)&&
+        Objects.equals(this.additionalProperties, bankStatementsInvalidException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class BankStatementsInvalidException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class BankStatementsInvalidException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BankStatementsInvalidException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BankStatementsInvalidException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BankStatementsInvalidException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class BankStatementsInvalidException {
            @Override
            public void write(JsonWriter out, BankStatementsInvalidException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class BankStatementsInvalidException {
            public BankStatementsInvalidException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BankStatementsInvalidException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/Business.java
+++ b/java/src/main/java/com/kanmon/client/model/Business.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -330,6 +330,50 @@ public class Business {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the Business instance itself
+   */
+  public Business putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -352,7 +396,8 @@ public class Business {
         Objects.equals(this.metadata, business.metadata) &&
         Objects.equals(this.isSoleProprietorship, business.isSoleProprietorship) &&
         Objects.equals(this.createdAt, business.createdAt) &&
-        Objects.equals(this.updatedAt, business.updatedAt);
+        Objects.equals(this.updatedAt, business.updatedAt)&&
+        Objects.equals(this.additionalProperties, business.additionalProperties);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -361,7 +406,7 @@ public class Business {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, platformBusinessId, name, address, ein, phoneNumber, website, customInitializationName, metadata, isSoleProprietorship, createdAt, updatedAt);
+    return Objects.hash(id, platformBusinessId, name, address, ein, phoneNumber, website, customInitializationName, metadata, isSoleProprietorship, createdAt, updatedAt, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -387,6 +432,7 @@ public class Business {
     sb.append("    isSoleProprietorship: ").append(toIndentedString(isSoleProprietorship)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -447,14 +493,6 @@ public class Business {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!Business.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Business` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : Business.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -510,6 +548,28 @@ public class Business {
            @Override
            public void write(JsonWriter out, Business value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -517,7 +577,28 @@ public class Business {
            public Business read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             Business instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BusinessAlreadyExistsException.java
+++ b/java/src/main/java/com/kanmon/client/model/BusinessAlreadyExistsException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class BusinessAlreadyExistsException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BusinessAlreadyExistsException instance itself
+   */
+  public BusinessAlreadyExistsException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class BusinessAlreadyExistsException {
     BusinessAlreadyExistsException businessAlreadyExistsException = (BusinessAlreadyExistsException) o;
     return Objects.equals(this.errorCode, businessAlreadyExistsException.errorCode) &&
         Objects.equals(this.message, businessAlreadyExistsException.message) &&
-        Objects.equals(this.timestamp, businessAlreadyExistsException.timestamp);
+        Objects.equals(this.timestamp, businessAlreadyExistsException.timestamp)&&
+        Objects.equals(this.additionalProperties, businessAlreadyExistsException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class BusinessAlreadyExistsException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class BusinessAlreadyExistsException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BusinessAlreadyExistsException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BusinessAlreadyExistsException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BusinessAlreadyExistsException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class BusinessAlreadyExistsException {
            @Override
            public void write(JsonWriter out, BusinessAlreadyExistsException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class BusinessAlreadyExistsException {
            public BusinessAlreadyExistsException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BusinessAlreadyExistsException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BusinessBankAccount.java
+++ b/java/src/main/java/com/kanmon/client/model/BusinessBankAccount.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -369,6 +369,50 @@ public class BusinessBankAccount {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BusinessBankAccount instance itself
+   */
+  public BusinessBankAccount putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -388,12 +432,13 @@ public class BusinessBankAccount {
         Objects.equals(this.accountType, businessBankAccount.accountType) &&
         Objects.equals(this.roles, businessBankAccount.roles) &&
         Objects.equals(this.createdAt, businessBankAccount.createdAt) &&
-        Objects.equals(this.updatedAt, businessBankAccount.updatedAt);
+        Objects.equals(this.updatedAt, businessBankAccount.updatedAt)&&
+        Objects.equals(this.additionalProperties, businessBankAccount.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, platformBankAccountId, accountName, accountNumber, routingNumber, accountType, roles, createdAt, updatedAt);
+    return Objects.hash(id, platformBankAccountId, accountName, accountNumber, routingNumber, accountType, roles, createdAt, updatedAt, additionalProperties);
   }
 
   @Override
@@ -409,6 +454,7 @@ public class BusinessBankAccount {
     sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -464,14 +510,6 @@ public class BusinessBankAccount {
       if (jsonElement == null) {
         if (!BusinessBankAccount.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
           throw new IllegalArgumentException(String.format("The required field(s) %s in BusinessBankAccount is not found in the empty JSON string", BusinessBankAccount.openapiRequiredFields.toString()));
-        }
-      }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BusinessBankAccount.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BusinessBankAccount` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
         }
       }
 
@@ -531,6 +569,28 @@ public class BusinessBankAccount {
            @Override
            public void write(JsonWriter out, BusinessBankAccount value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -538,7 +598,28 @@ public class BusinessBankAccount {
            public BusinessBankAccount read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BusinessBankAccount instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BusinessDocument.java
+++ b/java/src/main/java/com/kanmon/client/model/BusinessDocument.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -214,6 +214,50 @@ public class BusinessDocument {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BusinessDocument instance itself
+   */
+  public BusinessDocument putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -231,12 +275,13 @@ public class BusinessDocument {
         Objects.equals(this.documentType, businessDocument.documentType) &&
         Objects.equals(this.originalFileName, businessDocument.originalFileName) &&
         Objects.equals(this.createdAt, businessDocument.createdAt) &&
-        Objects.equals(this.updatedAt, businessDocument.updatedAt);
+        Objects.equals(this.updatedAt, businessDocument.updatedAt)&&
+        Objects.equals(this.additionalProperties, businessDocument.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, platformBusinessId, businessId, documentType, originalFileName, createdAt, updatedAt);
+    return Objects.hash(id, platformBusinessId, businessId, documentType, originalFileName, createdAt, updatedAt, additionalProperties);
   }
 
   @Override
@@ -250,6 +295,7 @@ public class BusinessDocument {
     sb.append("    originalFileName: ").append(toIndentedString(originalFileName)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -304,14 +350,6 @@ public class BusinessDocument {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BusinessDocument.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BusinessDocument` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BusinessDocument.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -356,6 +394,28 @@ public class BusinessDocument {
            @Override
            public void write(JsonWriter out, BusinessDocument value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -363,7 +423,28 @@ public class BusinessDocument {
            public BusinessDocument read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BusinessDocument instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BusinessDocumentType.java
+++ b/java/src/main/java/com/kanmon/client/model/BusinessDocumentType.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/BusinessHasNoAccountsPayableFinancingProductException.java
+++ b/java/src/main/java/com/kanmon/client/model/BusinessHasNoAccountsPayableFinancingProductException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class BusinessHasNoAccountsPayableFinancingProductException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BusinessHasNoAccountsPayableFinancingProductException instance itself
+   */
+  public BusinessHasNoAccountsPayableFinancingProductException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class BusinessHasNoAccountsPayableFinancingProductException {
     BusinessHasNoAccountsPayableFinancingProductException businessHasNoAccountsPayableFinancingProductException = (BusinessHasNoAccountsPayableFinancingProductException) o;
     return Objects.equals(this.errorCode, businessHasNoAccountsPayableFinancingProductException.errorCode) &&
         Objects.equals(this.message, businessHasNoAccountsPayableFinancingProductException.message) &&
-        Objects.equals(this.timestamp, businessHasNoAccountsPayableFinancingProductException.timestamp);
+        Objects.equals(this.timestamp, businessHasNoAccountsPayableFinancingProductException.timestamp)&&
+        Objects.equals(this.additionalProperties, businessHasNoAccountsPayableFinancingProductException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class BusinessHasNoAccountsPayableFinancingProductException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class BusinessHasNoAccountsPayableFinancingProductException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BusinessHasNoAccountsPayableFinancingProductException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BusinessHasNoAccountsPayableFinancingProductException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BusinessHasNoAccountsPayableFinancingProductException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class BusinessHasNoAccountsPayableFinancingProductException {
            @Override
            public void write(JsonWriter out, BusinessHasNoAccountsPayableFinancingProductException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class BusinessHasNoAccountsPayableFinancingProductException {
            public BusinessHasNoAccountsPayableFinancingProductException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BusinessHasNoAccountsPayableFinancingProductException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BusinessHasNoIntegratedMcaProductException.java
+++ b/java/src/main/java/com/kanmon/client/model/BusinessHasNoIntegratedMcaProductException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class BusinessHasNoIntegratedMcaProductException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BusinessHasNoIntegratedMcaProductException instance itself
+   */
+  public BusinessHasNoIntegratedMcaProductException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class BusinessHasNoIntegratedMcaProductException {
     BusinessHasNoIntegratedMcaProductException businessHasNoIntegratedMcaProductException = (BusinessHasNoIntegratedMcaProductException) o;
     return Objects.equals(this.errorCode, businessHasNoIntegratedMcaProductException.errorCode) &&
         Objects.equals(this.message, businessHasNoIntegratedMcaProductException.message) &&
-        Objects.equals(this.timestamp, businessHasNoIntegratedMcaProductException.timestamp);
+        Objects.equals(this.timestamp, businessHasNoIntegratedMcaProductException.timestamp)&&
+        Objects.equals(this.additionalProperties, businessHasNoIntegratedMcaProductException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class BusinessHasNoIntegratedMcaProductException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class BusinessHasNoIntegratedMcaProductException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BusinessHasNoIntegratedMcaProductException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BusinessHasNoIntegratedMcaProductException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BusinessHasNoIntegratedMcaProductException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class BusinessHasNoIntegratedMcaProductException {
            @Override
            public void write(JsonWriter out, BusinessHasNoIntegratedMcaProductException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class BusinessHasNoIntegratedMcaProductException {
            public BusinessHasNoIntegratedMcaProductException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BusinessHasNoIntegratedMcaProductException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BusinessHasNoInvoiceFinancingProductException.java
+++ b/java/src/main/java/com/kanmon/client/model/BusinessHasNoInvoiceFinancingProductException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class BusinessHasNoInvoiceFinancingProductException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BusinessHasNoInvoiceFinancingProductException instance itself
+   */
+  public BusinessHasNoInvoiceFinancingProductException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class BusinessHasNoInvoiceFinancingProductException {
     BusinessHasNoInvoiceFinancingProductException businessHasNoInvoiceFinancingProductException = (BusinessHasNoInvoiceFinancingProductException) o;
     return Objects.equals(this.errorCode, businessHasNoInvoiceFinancingProductException.errorCode) &&
         Objects.equals(this.message, businessHasNoInvoiceFinancingProductException.message) &&
-        Objects.equals(this.timestamp, businessHasNoInvoiceFinancingProductException.timestamp);
+        Objects.equals(this.timestamp, businessHasNoInvoiceFinancingProductException.timestamp)&&
+        Objects.equals(this.additionalProperties, businessHasNoInvoiceFinancingProductException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class BusinessHasNoInvoiceFinancingProductException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class BusinessHasNoInvoiceFinancingProductException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BusinessHasNoInvoiceFinancingProductException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BusinessHasNoInvoiceFinancingProductException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BusinessHasNoInvoiceFinancingProductException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class BusinessHasNoInvoiceFinancingProductException {
            @Override
            public void write(JsonWriter out, BusinessHasNoInvoiceFinancingProductException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class BusinessHasNoInvoiceFinancingProductException {
            public BusinessHasNoInvoiceFinancingProductException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BusinessHasNoInvoiceFinancingProductException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BusinessHasNoPrimaryOwnerException.java
+++ b/java/src/main/java/com/kanmon/client/model/BusinessHasNoPrimaryOwnerException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class BusinessHasNoPrimaryOwnerException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BusinessHasNoPrimaryOwnerException instance itself
+   */
+  public BusinessHasNoPrimaryOwnerException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class BusinessHasNoPrimaryOwnerException {
     BusinessHasNoPrimaryOwnerException businessHasNoPrimaryOwnerException = (BusinessHasNoPrimaryOwnerException) o;
     return Objects.equals(this.errorCode, businessHasNoPrimaryOwnerException.errorCode) &&
         Objects.equals(this.message, businessHasNoPrimaryOwnerException.message) &&
-        Objects.equals(this.timestamp, businessHasNoPrimaryOwnerException.timestamp);
+        Objects.equals(this.timestamp, businessHasNoPrimaryOwnerException.timestamp)&&
+        Objects.equals(this.additionalProperties, businessHasNoPrimaryOwnerException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class BusinessHasNoPrimaryOwnerException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class BusinessHasNoPrimaryOwnerException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BusinessHasNoPrimaryOwnerException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BusinessHasNoPrimaryOwnerException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BusinessHasNoPrimaryOwnerException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class BusinessHasNoPrimaryOwnerException {
            @Override
            public void write(JsonWriter out, BusinessHasNoPrimaryOwnerException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class BusinessHasNoPrimaryOwnerException {
            public BusinessHasNoPrimaryOwnerException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BusinessHasNoPrimaryOwnerException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BusinessNotFoundException.java
+++ b/java/src/main/java/com/kanmon/client/model/BusinessNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class BusinessNotFoundException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BusinessNotFoundException instance itself
+   */
+  public BusinessNotFoundException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class BusinessNotFoundException {
     BusinessNotFoundException businessNotFoundException = (BusinessNotFoundException) o;
     return Objects.equals(this.errorCode, businessNotFoundException.errorCode) &&
         Objects.equals(this.message, businessNotFoundException.message) &&
-        Objects.equals(this.timestamp, businessNotFoundException.timestamp);
+        Objects.equals(this.timestamp, businessNotFoundException.timestamp)&&
+        Objects.equals(this.additionalProperties, businessNotFoundException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class BusinessNotFoundException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class BusinessNotFoundException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BusinessNotFoundException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BusinessNotFoundException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BusinessNotFoundException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class BusinessNotFoundException {
            @Override
            public void write(JsonWriter out, BusinessNotFoundException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class BusinessNotFoundException {
            public BusinessNotFoundException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BusinessNotFoundException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BusinessPlaidBankAccountNotFoundException.java
+++ b/java/src/main/java/com/kanmon/client/model/BusinessPlaidBankAccountNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class BusinessPlaidBankAccountNotFoundException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BusinessPlaidBankAccountNotFoundException instance itself
+   */
+  public BusinessPlaidBankAccountNotFoundException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class BusinessPlaidBankAccountNotFoundException {
     BusinessPlaidBankAccountNotFoundException businessPlaidBankAccountNotFoundException = (BusinessPlaidBankAccountNotFoundException) o;
     return Objects.equals(this.errorCode, businessPlaidBankAccountNotFoundException.errorCode) &&
         Objects.equals(this.message, businessPlaidBankAccountNotFoundException.message) &&
-        Objects.equals(this.timestamp, businessPlaidBankAccountNotFoundException.timestamp);
+        Objects.equals(this.timestamp, businessPlaidBankAccountNotFoundException.timestamp)&&
+        Objects.equals(this.additionalProperties, businessPlaidBankAccountNotFoundException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class BusinessPlaidBankAccountNotFoundException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class BusinessPlaidBankAccountNotFoundException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BusinessPlaidBankAccountNotFoundException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BusinessPlaidBankAccountNotFoundException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BusinessPlaidBankAccountNotFoundException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class BusinessPlaidBankAccountNotFoundException {
            @Override
            public void write(JsonWriter out, BusinessPlaidBankAccountNotFoundException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class BusinessPlaidBankAccountNotFoundException {
            public BusinessPlaidBankAccountNotFoundException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BusinessPlaidBankAccountNotFoundException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/BusinessPrequalification.java
+++ b/java/src/main/java/com/kanmon/client/model/BusinessPrequalification.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -238,6 +238,50 @@ public class BusinessPrequalification {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the BusinessPrequalification instance itself
+   */
+  public BusinessPrequalification putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -256,12 +300,13 @@ public class BusinessPrequalification {
         Objects.equals(this.isPrequalified, businessPrequalification.isPrequalified) &&
         Objects.equals(this.prequalifiedAmountCents, businessPrequalification.prequalifiedAmountCents) &&
         Objects.equals(this.createdAt, businessPrequalification.createdAt) &&
-        Objects.equals(this.updatedAt, businessPrequalification.updatedAt);
+        Objects.equals(this.updatedAt, businessPrequalification.updatedAt)&&
+        Objects.equals(this.additionalProperties, businessPrequalification.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(product, platformId, businessId, platformBusinessId, isPrequalified, prequalifiedAmountCents, createdAt, updatedAt);
+    return Objects.hash(product, platformId, businessId, platformBusinessId, isPrequalified, prequalifiedAmountCents, createdAt, updatedAt, additionalProperties);
   }
 
   @Override
@@ -276,6 +321,7 @@ public class BusinessPrequalification {
     sb.append("    prequalifiedAmountCents: ").append(toIndentedString(prequalifiedAmountCents)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -332,14 +378,6 @@ public class BusinessPrequalification {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!BusinessPrequalification.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `BusinessPrequalification` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : BusinessPrequalification.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -381,6 +419,28 @@ public class BusinessPrequalification {
            @Override
            public void write(JsonWriter out, BusinessPrequalification value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -388,7 +448,28 @@ public class BusinessPrequalification {
            public BusinessPrequalification read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             BusinessPrequalification instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/CheckingAccountRequiredException.java
+++ b/java/src/main/java/com/kanmon/client/model/CheckingAccountRequiredException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class CheckingAccountRequiredException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CheckingAccountRequiredException instance itself
+   */
+  public CheckingAccountRequiredException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class CheckingAccountRequiredException {
     CheckingAccountRequiredException checkingAccountRequiredException = (CheckingAccountRequiredException) o;
     return Objects.equals(this.errorCode, checkingAccountRequiredException.errorCode) &&
         Objects.equals(this.message, checkingAccountRequiredException.message) &&
-        Objects.equals(this.timestamp, checkingAccountRequiredException.timestamp);
+        Objects.equals(this.timestamp, checkingAccountRequiredException.timestamp)&&
+        Objects.equals(this.additionalProperties, checkingAccountRequiredException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class CheckingAccountRequiredException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class CheckingAccountRequiredException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CheckingAccountRequiredException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CheckingAccountRequiredException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : CheckingAccountRequiredException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class CheckingAccountRequiredException {
            @Override
            public void write(JsonWriter out, CheckingAccountRequiredException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class CheckingAccountRequiredException {
            public CheckingAccountRequiredException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CheckingAccountRequiredException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/ConnectToken.java
+++ b/java/src/main/java/com/kanmon/client/model/ConnectToken.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -75,6 +75,50 @@ public class ConnectToken {
     this.connectToken = connectToken;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the ConnectToken instance itself
+   */
+  public ConnectToken putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -86,12 +130,13 @@ public class ConnectToken {
       return false;
     }
     ConnectToken connectToken = (ConnectToken) o;
-    return Objects.equals(this.connectToken, connectToken.connectToken);
+    return Objects.equals(this.connectToken, connectToken.connectToken)&&
+        Objects.equals(this.additionalProperties, connectToken.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(connectToken);
+    return Objects.hash(connectToken, additionalProperties);
   }
 
   @Override
@@ -99,6 +144,7 @@ public class ConnectToken {
     StringBuilder sb = new StringBuilder();
     sb.append("class ConnectToken {\n");
     sb.append("    connectToken: ").append(toIndentedString(connectToken)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -141,14 +187,6 @@ public class ConnectToken {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!ConnectToken.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ConnectToken` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : ConnectToken.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -176,6 +214,28 @@ public class ConnectToken {
            @Override
            public void write(JsonWriter out, ConnectToken value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -183,7 +243,28 @@ public class ConnectToken {
            public ConnectToken read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             ConnectToken instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/CreateBusiness404Response.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateBusiness404Response.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/CreateBusinessBankAccountRequestBody.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateBusinessBankAccountRequestBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -346,6 +346,50 @@ public class CreateBusinessBankAccountRequestBody {
     this.roles = roles;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CreateBusinessBankAccountRequestBody instance itself
+   */
+  public CreateBusinessBankAccountRequestBody putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -364,12 +408,13 @@ public class CreateBusinessBankAccountRequestBody {
         Objects.equals(this.accountNumber, createBusinessBankAccountRequestBody.accountNumber) &&
         Objects.equals(this.routingNumber, createBusinessBankAccountRequestBody.routingNumber) &&
         Objects.equals(this.accountType, createBusinessBankAccountRequestBody.accountType) &&
-        Objects.equals(this.roles, createBusinessBankAccountRequestBody.roles);
+        Objects.equals(this.roles, createBusinessBankAccountRequestBody.roles)&&
+        Objects.equals(this.additionalProperties, createBusinessBankAccountRequestBody.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(platformBusinessId, businessId, platformBankAccountId, accountName, accountNumber, routingNumber, accountType, roles);
+    return Objects.hash(platformBusinessId, businessId, platformBankAccountId, accountName, accountNumber, routingNumber, accountType, roles, additionalProperties);
   }
 
   @Override
@@ -384,6 +429,7 @@ public class CreateBusinessBankAccountRequestBody {
     sb.append("    routingNumber: ").append(toIndentedString(routingNumber)).append("\n");
     sb.append("    accountType: ").append(toIndentedString(accountType)).append("\n");
     sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -435,14 +481,6 @@ public class CreateBusinessBankAccountRequestBody {
       if (jsonElement == null) {
         if (!CreateBusinessBankAccountRequestBody.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
           throw new IllegalArgumentException(String.format("The required field(s) %s in CreateBusinessBankAccountRequestBody is not found in the empty JSON string", CreateBusinessBankAccountRequestBody.openapiRequiredFields.toString()));
-        }
-      }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CreateBusinessBankAccountRequestBody.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateBusinessBankAccountRequestBody` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
         }
       }
 
@@ -499,6 +537,28 @@ public class CreateBusinessBankAccountRequestBody {
            @Override
            public void write(JsonWriter out, CreateBusinessBankAccountRequestBody value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -506,7 +566,28 @@ public class CreateBusinessBankAccountRequestBody {
            public CreateBusinessBankAccountRequestBody read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CreateBusinessBankAccountRequestBody instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/CreateBusinessDocumentsResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateBusinessDocumentsResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -86,6 +86,50 @@ public class CreateBusinessDocumentsResponse {
     this.documents = documents;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CreateBusinessDocumentsResponse instance itself
+   */
+  public CreateBusinessDocumentsResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -97,12 +141,13 @@ public class CreateBusinessDocumentsResponse {
       return false;
     }
     CreateBusinessDocumentsResponse createBusinessDocumentsResponse = (CreateBusinessDocumentsResponse) o;
-    return Objects.equals(this.documents, createBusinessDocumentsResponse.documents);
+    return Objects.equals(this.documents, createBusinessDocumentsResponse.documents)&&
+        Objects.equals(this.additionalProperties, createBusinessDocumentsResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(documents);
+    return Objects.hash(documents, additionalProperties);
   }
 
   @Override
@@ -110,6 +155,7 @@ public class CreateBusinessDocumentsResponse {
     StringBuilder sb = new StringBuilder();
     sb.append("class CreateBusinessDocumentsResponse {\n");
     sb.append("    documents: ").append(toIndentedString(documents)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -152,14 +198,6 @@ public class CreateBusinessDocumentsResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CreateBusinessDocumentsResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateBusinessDocumentsResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : CreateBusinessDocumentsResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -194,6 +232,28 @@ public class CreateBusinessDocumentsResponse {
            @Override
            public void write(JsonWriter out, CreateBusinessDocumentsResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -201,7 +261,28 @@ public class CreateBusinessDocumentsResponse {
            public CreateBusinessDocumentsResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CreateBusinessDocumentsResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/CreateBusinessRequestBody.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateBusinessRequestBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -260,6 +260,50 @@ public class CreateBusinessRequestBody {
     this.isSoleProprietorship = isSoleProprietorship;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CreateBusinessRequestBody instance itself
+   */
+  public CreateBusinessRequestBody putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -279,12 +323,13 @@ public class CreateBusinessRequestBody {
         Objects.equals(this.website, createBusinessRequestBody.website) &&
         Objects.equals(this.customInitializationName, createBusinessRequestBody.customInitializationName) &&
         Objects.equals(this.metadata, createBusinessRequestBody.metadata) &&
-        Objects.equals(this.isSoleProprietorship, createBusinessRequestBody.isSoleProprietorship);
+        Objects.equals(this.isSoleProprietorship, createBusinessRequestBody.isSoleProprietorship)&&
+        Objects.equals(this.additionalProperties, createBusinessRequestBody.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(platformBusinessId, name, address, ein, phoneNumber, website, customInitializationName, metadata, isSoleProprietorship);
+    return Objects.hash(platformBusinessId, name, address, ein, phoneNumber, website, customInitializationName, metadata, isSoleProprietorship, additionalProperties);
   }
 
   @Override
@@ -300,6 +345,7 @@ public class CreateBusinessRequestBody {
     sb.append("    customInitializationName: ").append(toIndentedString(customInitializationName)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("    isSoleProprietorship: ").append(toIndentedString(isSoleProprietorship)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -350,14 +396,6 @@ public class CreateBusinessRequestBody {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CreateBusinessRequestBody.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateBusinessRequestBody` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : CreateBusinessRequestBody.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -404,6 +442,28 @@ public class CreateBusinessRequestBody {
            @Override
            public void write(JsonWriter out, CreateBusinessRequestBody value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -411,7 +471,28 @@ public class CreateBusinessRequestBody {
            public CreateBusinessRequestBody read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CreateBusinessRequestBody instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/CreateConnectTokenRequestBody.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateConnectTokenRequestBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -98,6 +98,50 @@ public class CreateConnectTokenRequestBody {
     this.platformUserId = platformUserId;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CreateConnectTokenRequestBody instance itself
+   */
+  public CreateConnectTokenRequestBody putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -110,12 +154,13 @@ public class CreateConnectTokenRequestBody {
     }
     CreateConnectTokenRequestBody createConnectTokenRequestBody = (CreateConnectTokenRequestBody) o;
     return Objects.equals(this.userId, createConnectTokenRequestBody.userId) &&
-        Objects.equals(this.platformUserId, createConnectTokenRequestBody.platformUserId);
+        Objects.equals(this.platformUserId, createConnectTokenRequestBody.platformUserId)&&
+        Objects.equals(this.additionalProperties, createConnectTokenRequestBody.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(userId, platformUserId);
+    return Objects.hash(userId, platformUserId, additionalProperties);
   }
 
   @Override
@@ -124,6 +169,7 @@ public class CreateConnectTokenRequestBody {
     sb.append("class CreateConnectTokenRequestBody {\n");
     sb.append("    userId: ").append(toIndentedString(userId)).append("\n");
     sb.append("    platformUserId: ").append(toIndentedString(platformUserId)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -165,14 +211,6 @@ public class CreateConnectTokenRequestBody {
           throw new IllegalArgumentException(String.format("The required field(s) %s in CreateConnectTokenRequestBody is not found in the empty JSON string", CreateConnectTokenRequestBody.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CreateConnectTokenRequestBody.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateConnectTokenRequestBody` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("userId") != null && !jsonObj.get("userId").isJsonNull()) && !jsonObj.get("userId").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `userId` to be a primitive type in the JSON string but got `%s`", jsonObj.get("userId").toString()));
@@ -197,6 +235,28 @@ public class CreateConnectTokenRequestBody {
            @Override
            public void write(JsonWriter out, CreateConnectTokenRequestBody value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -204,7 +264,28 @@ public class CreateConnectTokenRequestBody {
            public CreateConnectTokenRequestBody read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CreateConnectTokenRequestBody instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/CreateEmbeddedSession409Response.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateEmbeddedSession409Response.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/CreateIntegratedMcaReceivable400Response.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateIntegratedMcaReceivable400Response.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/CreateIntegratedMcaReceivable409Response.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateIntegratedMcaReceivable409Response.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/CreateIntegratedMcaReceivableBody.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateIntegratedMcaReceivableBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -168,6 +168,50 @@ public class CreateIntegratedMcaReceivableBody {
     this.transactionTime = transactionTime;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CreateIntegratedMcaReceivableBody instance itself
+   */
+  public CreateIntegratedMcaReceivableBody putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -183,12 +227,13 @@ public class CreateIntegratedMcaReceivableBody {
         Objects.equals(this.chargeAmountCents, createIntegratedMcaReceivableBody.chargeAmountCents) &&
         Objects.equals(this.repaymentAmountCents, createIntegratedMcaReceivableBody.repaymentAmountCents) &&
         Objects.equals(this.transactionId, createIntegratedMcaReceivableBody.transactionId) &&
-        Objects.equals(this.transactionTime, createIntegratedMcaReceivableBody.transactionTime);
+        Objects.equals(this.transactionTime, createIntegratedMcaReceivableBody.transactionTime)&&
+        Objects.equals(this.additionalProperties, createIntegratedMcaReceivableBody.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(issuedProductId, chargeAmountCents, repaymentAmountCents, transactionId, transactionTime);
+    return Objects.hash(issuedProductId, chargeAmountCents, repaymentAmountCents, transactionId, transactionTime, additionalProperties);
   }
 
   @Override
@@ -200,6 +245,7 @@ public class CreateIntegratedMcaReceivableBody {
     sb.append("    repaymentAmountCents: ").append(toIndentedString(repaymentAmountCents)).append("\n");
     sb.append("    transactionId: ").append(toIndentedString(transactionId)).append("\n");
     sb.append("    transactionTime: ").append(toIndentedString(transactionTime)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -250,14 +296,6 @@ public class CreateIntegratedMcaReceivableBody {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CreateIntegratedMcaReceivableBody.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateIntegratedMcaReceivableBody` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : CreateIntegratedMcaReceivableBody.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -291,6 +329,28 @@ public class CreateIntegratedMcaReceivableBody {
            @Override
            public void write(JsonWriter out, CreateIntegratedMcaReceivableBody value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -298,7 +358,28 @@ public class CreateIntegratedMcaReceivableBody {
            public CreateIntegratedMcaReceivableBody read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CreateIntegratedMcaReceivableBody instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/CreateSessionTokenRequestBody.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateSessionTokenRequestBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -122,6 +122,50 @@ public class CreateSessionTokenRequestBody {
     this.data = data;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CreateSessionTokenRequestBody instance itself
+   */
+  public CreateSessionTokenRequestBody putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -135,12 +179,13 @@ public class CreateSessionTokenRequestBody {
     CreateSessionTokenRequestBody createSessionTokenRequestBody = (CreateSessionTokenRequestBody) o;
     return Objects.equals(this.businessId, createSessionTokenRequestBody.businessId) &&
         Objects.equals(this.platformBusinessId, createSessionTokenRequestBody.platformBusinessId) &&
-        Objects.equals(this.data, createSessionTokenRequestBody.data);
+        Objects.equals(this.data, createSessionTokenRequestBody.data)&&
+        Objects.equals(this.additionalProperties, createSessionTokenRequestBody.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(businessId, platformBusinessId, data);
+    return Objects.hash(businessId, platformBusinessId, data, additionalProperties);
   }
 
   @Override
@@ -150,6 +195,7 @@ public class CreateSessionTokenRequestBody {
     sb.append("    businessId: ").append(toIndentedString(businessId)).append("\n");
     sb.append("    platformBusinessId: ").append(toIndentedString(platformBusinessId)).append("\n");
     sb.append("    data: ").append(toIndentedString(data)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -194,14 +240,6 @@ public class CreateSessionTokenRequestBody {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CreateSessionTokenRequestBody.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateSessionTokenRequestBody` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : CreateSessionTokenRequestBody.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -234,6 +272,28 @@ public class CreateSessionTokenRequestBody {
            @Override
            public void write(JsonWriter out, CreateSessionTokenRequestBody value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -241,7 +301,28 @@ public class CreateSessionTokenRequestBody {
            public CreateSessionTokenRequestBody read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CreateSessionTokenRequestBody instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/CreateSessionTokenRequestBodyData.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateSessionTokenRequestBodyData.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/CreateUser409Response.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateUser409Response.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/CreateUserRequestBody.java
+++ b/java/src/main/java/com/kanmon/client/model/CreateUserRequestBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -318,7 +318,7 @@ public class CreateUserRequestBody {
   }
 
   /**
-   * The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. &lt;br/&gt;&lt;br/&gt;A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. &lt;br/&gt;&lt;br/&gt;An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. &lt;br /&gt;&lt;br/&gt;Please note Kanmon supports an additional user role called secondary owners. Secondary owners are beneficial owners of a business, like primary owners, and Kanmon must perform KYC checks for these users. Kanmon will handle creating and managing these users for KYC purposes through a separate process. &lt;br/&gt;
+   * The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. &lt;br/&gt;&lt;br/&gt;A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. &lt;br/&gt;&lt;br/&gt;An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. &lt;br /&gt;&lt;br/&gt;A secondary owner is a beneficial owner of the business who must complete KYC. This means the user can sign financing agreements when required and service an active issued product. During onboarding, the primary owner invites secondary owners. Secondary owners are directed to a separate Kanmon-hosted page where they complete onboarding, sign legal documents, and KYC. They can also access servicing from that page. Kanmon sends a &#x60;USER.CREATED&#x60; webhook when a secondary owner is created.
    * @return roles
    */
   @javax.annotation.Nullable
@@ -368,6 +368,50 @@ public class CreateUserRequestBody {
     this.isUsCitizen = isUsCitizen;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CreateUserRequestBody instance itself
+   */
+  public CreateUserRequestBody putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -389,12 +433,13 @@ public class CreateUserRequestBody {
         Objects.equals(this.address, createUserRequestBody.address) &&
         Objects.equals(this.roles, createUserRequestBody.roles) &&
         Objects.equals(this.metadata, createUserRequestBody.metadata) &&
-        Objects.equals(this.isUsCitizen, createUserRequestBody.isUsCitizen);
+        Objects.equals(this.isUsCitizen, createUserRequestBody.isUsCitizen)&&
+        Objects.equals(this.additionalProperties, createUserRequestBody.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(platformUserId, platformBusinessId, businessId, email, firstName, lastName, phoneNumber, address, roles, metadata, isUsCitizen);
+    return Objects.hash(platformUserId, platformBusinessId, businessId, email, firstName, lastName, phoneNumber, address, roles, metadata, isUsCitizen, additionalProperties);
   }
 
   @Override
@@ -412,6 +457,7 @@ public class CreateUserRequestBody {
     sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("    isUsCitizen: ").append(toIndentedString(isUsCitizen)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -461,14 +507,6 @@ public class CreateUserRequestBody {
       if (jsonElement == null) {
         if (!CreateUserRequestBody.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
           throw new IllegalArgumentException(String.format("The required field(s) %s in CreateUserRequestBody is not found in the empty JSON string", CreateUserRequestBody.openapiRequiredFields.toString()));
-        }
-      }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CreateUserRequestBody.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CreateUserRequestBody` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
         }
       }
 
@@ -525,6 +563,28 @@ public class CreateUserRequestBody {
            @Override
            public void write(JsonWriter out, CreateUserRequestBody value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -532,7 +592,28 @@ public class CreateUserRequestBody {
            public CreateUserRequestBody read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CreateUserRequestBody instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/CustomInitializationNotFoundException.java
+++ b/java/src/main/java/com/kanmon/client/model/CustomInitializationNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class CustomInitializationNotFoundException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the CustomInitializationNotFoundException instance itself
+   */
+  public CustomInitializationNotFoundException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class CustomInitializationNotFoundException {
     CustomInitializationNotFoundException customInitializationNotFoundException = (CustomInitializationNotFoundException) o;
     return Objects.equals(this.errorCode, customInitializationNotFoundException.errorCode) &&
         Objects.equals(this.message, customInitializationNotFoundException.message) &&
-        Objects.equals(this.timestamp, customInitializationNotFoundException.timestamp);
+        Objects.equals(this.timestamp, customInitializationNotFoundException.timestamp)&&
+        Objects.equals(this.additionalProperties, customInitializationNotFoundException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class CustomInitializationNotFoundException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class CustomInitializationNotFoundException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!CustomInitializationNotFoundException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `CustomInitializationNotFoundException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : CustomInitializationNotFoundException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class CustomInitializationNotFoundException {
            @Override
            public void write(JsonWriter out, CustomInitializationNotFoundException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class CustomInitializationNotFoundException {
            public CustomInitializationNotFoundException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             CustomInitializationNotFoundException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/DrawRequest.java
+++ b/java/src/main/java/com/kanmon/client/model/DrawRequest.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -20,6 +20,7 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.kanmon.client.model.DrawRequestState;
+import com.kanmon.client.model.RepaymentCadence;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -85,8 +86,25 @@ public class DrawRequest {
   private BigDecimal feePercentage;
 
   public static final String SERIALIZED_NAME_REPAYMENT_DURATION_MONTHS = "repaymentDurationMonths";
+  @Deprecated
   @SerializedName(SERIALIZED_NAME_REPAYMENT_DURATION_MONTHS)
   private BigDecimal repaymentDurationMonths;
+
+  public static final String SERIALIZED_NAME_REPAYMENT_CADENCE = "repaymentCadence";
+  @SerializedName(SERIALIZED_NAME_REPAYMENT_CADENCE)
+  private RepaymentCadence repaymentCadence;
+
+  public static final String SERIALIZED_NAME_GRACE_PERIOD_DAYS = "gracePeriodDays";
+  @SerializedName(SERIALIZED_NAME_GRACE_PERIOD_DAYS)
+  private BigDecimal gracePeriodDays;
+
+  public static final String SERIALIZED_NAME_NUM_PAYMENT_PERIODS = "numPaymentPeriods";
+  @SerializedName(SERIALIZED_NAME_NUM_PAYMENT_PERIODS)
+  private BigDecimal numPaymentPeriods;
+
+  public static final String SERIALIZED_NAME_REMAINING_BALANCE_CENTS = "remainingBalanceCents";
+  @SerializedName(SERIALIZED_NAME_REMAINING_BALANCE_CENTS)
+  private BigDecimal remainingBalanceCents;
 
   public static final String SERIALIZED_NAME_CREATED_AT = "createdAt";
   @SerializedName(SERIALIZED_NAME_CREATED_AT)
@@ -251,22 +269,102 @@ public class DrawRequest {
   }
 
 
+  @Deprecated
   public DrawRequest repaymentDurationMonths(BigDecimal repaymentDurationMonths) {
     this.repaymentDurationMonths = repaymentDurationMonths;
     return this;
   }
 
   /**
-   * The duration of the repayment for the draw request - in months.
+   * The duration of the repayment for the draw request - in months. Deprecated: use &#x60;numPaymentPeriods&#x60; and &#x60;repaymentCadence&#x60; instead.
    * @return repaymentDurationMonths
+   * @deprecated
    */
+  @Deprecated
   @javax.annotation.Nonnull
   public BigDecimal getRepaymentDurationMonths() {
     return repaymentDurationMonths;
   }
 
+  @Deprecated
   public void setRepaymentDurationMonths(BigDecimal repaymentDurationMonths) {
     this.repaymentDurationMonths = repaymentDurationMonths;
+  }
+
+
+  public DrawRequest repaymentCadence(RepaymentCadence repaymentCadence) {
+    this.repaymentCadence = repaymentCadence;
+    return this;
+  }
+
+  /**
+   * Get repaymentCadence
+   * @return repaymentCadence
+   */
+  @javax.annotation.Nonnull
+  public RepaymentCadence getRepaymentCadence() {
+    return repaymentCadence;
+  }
+
+  public void setRepaymentCadence(RepaymentCadence repaymentCadence) {
+    this.repaymentCadence = repaymentCadence;
+  }
+
+
+  public DrawRequest gracePeriodDays(BigDecimal gracePeriodDays) {
+    this.gracePeriodDays = gracePeriodDays;
+    return this;
+  }
+
+  /**
+   * The number of days after the draw during which no installment payments are due. Interest still accrues.
+   * @return gracePeriodDays
+   */
+  @javax.annotation.Nonnull
+  public BigDecimal getGracePeriodDays() {
+    return gracePeriodDays;
+  }
+
+  public void setGracePeriodDays(BigDecimal gracePeriodDays) {
+    this.gracePeriodDays = gracePeriodDays;
+  }
+
+
+  public DrawRequest numPaymentPeriods(BigDecimal numPaymentPeriods) {
+    this.numPaymentPeriods = numPaymentPeriods;
+    return this;
+  }
+
+  /**
+   * The number of installment payment periods for the draw request.
+   * @return numPaymentPeriods
+   */
+  @javax.annotation.Nonnull
+  public BigDecimal getNumPaymentPeriods() {
+    return numPaymentPeriods;
+  }
+
+  public void setNumPaymentPeriods(BigDecimal numPaymentPeriods) {
+    this.numPaymentPeriods = numPaymentPeriods;
+  }
+
+
+  public DrawRequest remainingBalanceCents(BigDecimal remainingBalanceCents) {
+    this.remainingBalanceCents = remainingBalanceCents;
+    return this;
+  }
+
+  /**
+   * The outstanding principal balance on the draw request - in cents. Equal to the original draw amount minus confirmed principal repayments.
+   * @return remainingBalanceCents
+   */
+  @javax.annotation.Nonnull
+  public BigDecimal getRemainingBalanceCents() {
+    return remainingBalanceCents;
+  }
+
+  public void setRemainingBalanceCents(BigDecimal remainingBalanceCents) {
+    this.remainingBalanceCents = remainingBalanceCents;
   }
 
 
@@ -307,6 +405,50 @@ public class DrawRequest {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the DrawRequest instance itself
+   */
+  public DrawRequest putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -327,13 +469,18 @@ public class DrawRequest {
         Objects.equals(this.interestRatePercentage, drawRequest.interestRatePercentage) &&
         Objects.equals(this.feePercentage, drawRequest.feePercentage) &&
         Objects.equals(this.repaymentDurationMonths, drawRequest.repaymentDurationMonths) &&
+        Objects.equals(this.repaymentCadence, drawRequest.repaymentCadence) &&
+        Objects.equals(this.gracePeriodDays, drawRequest.gracePeriodDays) &&
+        Objects.equals(this.numPaymentPeriods, drawRequest.numPaymentPeriods) &&
+        Objects.equals(this.remainingBalanceCents, drawRequest.remainingBalanceCents) &&
         Objects.equals(this.createdAt, drawRequest.createdAt) &&
-        Objects.equals(this.updatedAt, drawRequest.updatedAt);
+        Objects.equals(this.updatedAt, drawRequest.updatedAt)&&
+        Objects.equals(this.additionalProperties, drawRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, issuedProductId, amountCents, disbursementAmountCents, feeAmountCents, status, interestRatePercentage, feePercentage, repaymentDurationMonths, createdAt, updatedAt);
+    return Objects.hash(id, issuedProductId, amountCents, disbursementAmountCents, feeAmountCents, status, interestRatePercentage, feePercentage, repaymentDurationMonths, repaymentCadence, gracePeriodDays, numPaymentPeriods, remainingBalanceCents, createdAt, updatedAt, additionalProperties);
   }
 
   @Override
@@ -349,8 +496,13 @@ public class DrawRequest {
     sb.append("    interestRatePercentage: ").append(toIndentedString(interestRatePercentage)).append("\n");
     sb.append("    feePercentage: ").append(toIndentedString(feePercentage)).append("\n");
     sb.append("    repaymentDurationMonths: ").append(toIndentedString(repaymentDurationMonths)).append("\n");
+    sb.append("    repaymentCadence: ").append(toIndentedString(repaymentCadence)).append("\n");
+    sb.append("    gracePeriodDays: ").append(toIndentedString(gracePeriodDays)).append("\n");
+    sb.append("    numPaymentPeriods: ").append(toIndentedString(numPaymentPeriods)).append("\n");
+    sb.append("    remainingBalanceCents: ").append(toIndentedString(remainingBalanceCents)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -382,6 +534,10 @@ public class DrawRequest {
     openapiFields.add("interestRatePercentage");
     openapiFields.add("feePercentage");
     openapiFields.add("repaymentDurationMonths");
+    openapiFields.add("repaymentCadence");
+    openapiFields.add("gracePeriodDays");
+    openapiFields.add("numPaymentPeriods");
+    openapiFields.add("remainingBalanceCents");
     openapiFields.add("createdAt");
     openapiFields.add("updatedAt");
 
@@ -396,6 +552,10 @@ public class DrawRequest {
     openapiRequiredFields.add("interestRatePercentage");
     openapiRequiredFields.add("feePercentage");
     openapiRequiredFields.add("repaymentDurationMonths");
+    openapiRequiredFields.add("repaymentCadence");
+    openapiRequiredFields.add("gracePeriodDays");
+    openapiRequiredFields.add("numPaymentPeriods");
+    openapiRequiredFields.add("remainingBalanceCents");
     openapiRequiredFields.add("createdAt");
     openapiRequiredFields.add("updatedAt");
   }
@@ -410,14 +570,6 @@ public class DrawRequest {
       if (jsonElement == null) {
         if (!DrawRequest.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
           throw new IllegalArgumentException(String.format("The required field(s) %s in DrawRequest is not found in the empty JSON string", DrawRequest.openapiRequiredFields.toString()));
-        }
-      }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!DrawRequest.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DrawRequest` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
         }
       }
 
@@ -436,6 +588,8 @@ public class DrawRequest {
       }
       // validate the required field `status`
       DrawRequestState.validateJsonElement(jsonObj.get("status"));
+      // validate the required field `repaymentCadence`
+      RepaymentCadence.validateJsonElement(jsonObj.get("repaymentCadence"));
       if (!jsonObj.get("createdAt").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `createdAt` to be a primitive type in the JSON string but got `%s`", jsonObj.get("createdAt").toString()));
       }
@@ -459,6 +613,28 @@ public class DrawRequest {
            @Override
            public void write(JsonWriter out, DrawRequest value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -466,7 +642,28 @@ public class DrawRequest {
            public DrawRequest read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             DrawRequest instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/DrawRequestNotFoundException.java
+++ b/java/src/main/java/com/kanmon/client/model/DrawRequestNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class DrawRequestNotFoundException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the DrawRequestNotFoundException instance itself
+   */
+  public DrawRequestNotFoundException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class DrawRequestNotFoundException {
     DrawRequestNotFoundException drawRequestNotFoundException = (DrawRequestNotFoundException) o;
     return Objects.equals(this.errorCode, drawRequestNotFoundException.errorCode) &&
         Objects.equals(this.message, drawRequestNotFoundException.message) &&
-        Objects.equals(this.timestamp, drawRequestNotFoundException.timestamp);
+        Objects.equals(this.timestamp, drawRequestNotFoundException.timestamp)&&
+        Objects.equals(this.additionalProperties, drawRequestNotFoundException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class DrawRequestNotFoundException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class DrawRequestNotFoundException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!DrawRequestNotFoundException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `DrawRequestNotFoundException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : DrawRequestNotFoundException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class DrawRequestNotFoundException {
            @Override
            public void write(JsonWriter out, DrawRequestNotFoundException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class DrawRequestNotFoundException {
            public DrawRequestNotFoundException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             DrawRequestNotFoundException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/DrawRequestState.java
+++ b/java/src/main/java/com/kanmon/client/model/DrawRequestState.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/EmbeddedSession.java
+++ b/java/src/main/java/com/kanmon/client/model/EmbeddedSession.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -75,6 +75,50 @@ public class EmbeddedSession {
     this.sessionToken = sessionToken;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the EmbeddedSession instance itself
+   */
+  public EmbeddedSession putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -86,12 +130,13 @@ public class EmbeddedSession {
       return false;
     }
     EmbeddedSession embeddedSession = (EmbeddedSession) o;
-    return Objects.equals(this.sessionToken, embeddedSession.sessionToken);
+    return Objects.equals(this.sessionToken, embeddedSession.sessionToken)&&
+        Objects.equals(this.additionalProperties, embeddedSession.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(sessionToken);
+    return Objects.hash(sessionToken, additionalProperties);
   }
 
   @Override
@@ -99,6 +144,7 @@ public class EmbeddedSession {
     StringBuilder sb = new StringBuilder();
     sb.append("class EmbeddedSession {\n");
     sb.append("    sessionToken: ").append(toIndentedString(sessionToken)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -141,14 +187,6 @@ public class EmbeddedSession {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!EmbeddedSession.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `EmbeddedSession` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : EmbeddedSession.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -176,6 +214,28 @@ public class EmbeddedSession {
            @Override
            public void write(JsonWriter out, EmbeddedSession value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -183,7 +243,28 @@ public class EmbeddedSession {
            public EmbeddedSession read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             EmbeddedSession instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/FinanceInvoice400Response.java
+++ b/java/src/main/java/com/kanmon/client/model/FinanceInvoice400Response.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/FinanceInvoice404Response.java
+++ b/java/src/main/java/com/kanmon/client/model/FinanceInvoice404Response.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/FinanceInvoice409Response.java
+++ b/java/src/main/java/com/kanmon/client/model/FinanceInvoice409Response.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/FinanceInvoiceRequestBody.java
+++ b/java/src/main/java/com/kanmon/client/model/FinanceInvoiceRequestBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -688,6 +688,50 @@ public class FinanceInvoiceRequestBody {
     this.payeeLastName = payeeLastName;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the FinanceInvoiceRequestBody instance itself
+   */
+  public FinanceInvoiceRequestBody putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -721,7 +765,8 @@ public class FinanceInvoiceRequestBody {
         Objects.equals(this.payeeBusinessName, financeInvoiceRequestBody.payeeBusinessName) &&
         Objects.equals(this.payeeFirstName, financeInvoiceRequestBody.payeeFirstName) &&
         Objects.equals(this.payeeMiddleName, financeInvoiceRequestBody.payeeMiddleName) &&
-        Objects.equals(this.payeeLastName, financeInvoiceRequestBody.payeeLastName);
+        Objects.equals(this.payeeLastName, financeInvoiceRequestBody.payeeLastName)&&
+        Objects.equals(this.additionalProperties, financeInvoiceRequestBody.additionalProperties);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -730,7 +775,7 @@ public class FinanceInvoiceRequestBody {
 
   @Override
   public int hashCode() {
-    return Objects.hash(issuedProductId, invoicePaymentPlanId, platformInvoiceId, platformInvoiceNumber, invoiceAmountCents, amountRequestedForFinancingCents, invoiceDueDate, invoiceIssuedDate, description, payorType, payorEmail, payorAddress, payorBusinessName, payorFirstName, payorMiddleName, payorLastName, payeeType, payeeEmail, payeeAddress, payeeBusinessName, payeeFirstName, payeeMiddleName, payeeLastName);
+    return Objects.hash(issuedProductId, invoicePaymentPlanId, platformInvoiceId, platformInvoiceNumber, invoiceAmountCents, amountRequestedForFinancingCents, invoiceDueDate, invoiceIssuedDate, description, payorType, payorEmail, payorAddress, payorBusinessName, payorFirstName, payorMiddleName, payorLastName, payeeType, payeeEmail, payeeAddress, payeeBusinessName, payeeFirstName, payeeMiddleName, payeeLastName, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -767,6 +812,7 @@ public class FinanceInvoiceRequestBody {
     sb.append("    payeeFirstName: ").append(toIndentedString(payeeFirstName)).append("\n");
     sb.append("    payeeMiddleName: ").append(toIndentedString(payeeMiddleName)).append("\n");
     sb.append("    payeeLastName: ").append(toIndentedString(payeeLastName)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -835,14 +881,6 @@ public class FinanceInvoiceRequestBody {
       if (jsonElement == null) {
         if (!FinanceInvoiceRequestBody.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
           throw new IllegalArgumentException(String.format("The required field(s) %s in FinanceInvoiceRequestBody is not found in the empty JSON string", FinanceInvoiceRequestBody.openapiRequiredFields.toString()));
-        }
-      }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!FinanceInvoiceRequestBody.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `FinanceInvoiceRequestBody` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
         }
       }
 
@@ -943,6 +981,28 @@ public class FinanceInvoiceRequestBody {
            @Override
            public void write(JsonWriter out, FinanceInvoiceRequestBody value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -950,7 +1010,28 @@ public class FinanceInvoiceRequestBody {
            public FinanceInvoiceRequestBody read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             FinanceInvoiceRequestBody instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/FixedDateInvoiceRepaymentWindow.java
+++ b/java/src/main/java/com/kanmon/client/model/FixedDateInvoiceRepaymentWindow.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -149,6 +149,50 @@ public class FixedDateInvoiceRepaymentWindow {
     this.monthlyRepaymentDay = monthlyRepaymentDay;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the FixedDateInvoiceRepaymentWindow instance itself
+   */
+  public FixedDateInvoiceRepaymentWindow putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -161,12 +205,13 @@ public class FixedDateInvoiceRepaymentWindow {
     }
     FixedDateInvoiceRepaymentWindow fixedDateInvoiceRepaymentWindow = (FixedDateInvoiceRepaymentWindow) o;
     return Objects.equals(this.repaymentType, fixedDateInvoiceRepaymentWindow.repaymentType) &&
-        Objects.equals(this.monthlyRepaymentDay, fixedDateInvoiceRepaymentWindow.monthlyRepaymentDay);
+        Objects.equals(this.monthlyRepaymentDay, fixedDateInvoiceRepaymentWindow.monthlyRepaymentDay)&&
+        Objects.equals(this.additionalProperties, fixedDateInvoiceRepaymentWindow.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(repaymentType, monthlyRepaymentDay);
+    return Objects.hash(repaymentType, monthlyRepaymentDay, additionalProperties);
   }
 
   @Override
@@ -175,6 +220,7 @@ public class FixedDateInvoiceRepaymentWindow {
     sb.append("class FixedDateInvoiceRepaymentWindow {\n");
     sb.append("    repaymentType: ").append(toIndentedString(repaymentType)).append("\n");
     sb.append("    monthlyRepaymentDay: ").append(toIndentedString(monthlyRepaymentDay)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -219,14 +265,6 @@ public class FixedDateInvoiceRepaymentWindow {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!FixedDateInvoiceRepaymentWindow.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `FixedDateInvoiceRepaymentWindow` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : FixedDateInvoiceRepaymentWindow.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -256,6 +294,28 @@ public class FixedDateInvoiceRepaymentWindow {
            @Override
            public void write(JsonWriter out, FixedDateInvoiceRepaymentWindow value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -263,7 +323,28 @@ public class FixedDateInvoiceRepaymentWindow {
            public FixedDateInvoiceRepaymentWindow read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             FixedDateInvoiceRepaymentWindow instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/FixedDurationInvoiceRepaymentWindow.java
+++ b/java/src/main/java/com/kanmon/client/model/FixedDurationInvoiceRepaymentWindow.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -149,6 +149,50 @@ public class FixedDurationInvoiceRepaymentWindow {
     this.repaymentDurationDays = repaymentDurationDays;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the FixedDurationInvoiceRepaymentWindow instance itself
+   */
+  public FixedDurationInvoiceRepaymentWindow putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -161,12 +205,13 @@ public class FixedDurationInvoiceRepaymentWindow {
     }
     FixedDurationInvoiceRepaymentWindow fixedDurationInvoiceRepaymentWindow = (FixedDurationInvoiceRepaymentWindow) o;
     return Objects.equals(this.repaymentType, fixedDurationInvoiceRepaymentWindow.repaymentType) &&
-        Objects.equals(this.repaymentDurationDays, fixedDurationInvoiceRepaymentWindow.repaymentDurationDays);
+        Objects.equals(this.repaymentDurationDays, fixedDurationInvoiceRepaymentWindow.repaymentDurationDays)&&
+        Objects.equals(this.additionalProperties, fixedDurationInvoiceRepaymentWindow.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(repaymentType, repaymentDurationDays);
+    return Objects.hash(repaymentType, repaymentDurationDays, additionalProperties);
   }
 
   @Override
@@ -175,6 +220,7 @@ public class FixedDurationInvoiceRepaymentWindow {
     sb.append("class FixedDurationInvoiceRepaymentWindow {\n");
     sb.append("    repaymentType: ").append(toIndentedString(repaymentType)).append("\n");
     sb.append("    repaymentDurationDays: ").append(toIndentedString(repaymentDurationDays)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -219,14 +265,6 @@ public class FixedDurationInvoiceRepaymentWindow {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!FixedDurationInvoiceRepaymentWindow.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `FixedDurationInvoiceRepaymentWindow` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : FixedDurationInvoiceRepaymentWindow.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -256,6 +294,28 @@ public class FixedDurationInvoiceRepaymentWindow {
            @Override
            public void write(JsonWriter out, FixedDurationInvoiceRepaymentWindow value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -263,7 +323,28 @@ public class FixedDurationInvoiceRepaymentWindow {
            public FixedDurationInvoiceRepaymentWindow read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             FixedDurationInvoiceRepaymentWindow instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/ForbiddenException.java
+++ b/java/src/main/java/com/kanmon/client/model/ForbiddenException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class ForbiddenException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the ForbiddenException instance itself
+   */
+  public ForbiddenException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class ForbiddenException {
     ForbiddenException forbiddenException = (ForbiddenException) o;
     return Objects.equals(this.errorCode, forbiddenException.errorCode) &&
         Objects.equals(this.message, forbiddenException.message) &&
-        Objects.equals(this.timestamp, forbiddenException.timestamp);
+        Objects.equals(this.timestamp, forbiddenException.timestamp)&&
+        Objects.equals(this.additionalProperties, forbiddenException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class ForbiddenException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class ForbiddenException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!ForbiddenException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `ForbiddenException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : ForbiddenException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class ForbiddenException {
            @Override
            public void write(JsonWriter out, ForbiddenException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class ForbiddenException {
            public ForbiddenException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             ForbiddenException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/GetActivityLogsResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/GetActivityLogsResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -110,6 +110,50 @@ public class GetActivityLogsResponse {
     this.pagination = pagination;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the GetActivityLogsResponse instance itself
+   */
+  public GetActivityLogsResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -122,12 +166,13 @@ public class GetActivityLogsResponse {
     }
     GetActivityLogsResponse getActivityLogsResponse = (GetActivityLogsResponse) o;
     return Objects.equals(this.activityLogs, getActivityLogsResponse.activityLogs) &&
-        Objects.equals(this.pagination, getActivityLogsResponse.pagination);
+        Objects.equals(this.pagination, getActivityLogsResponse.pagination)&&
+        Objects.equals(this.additionalProperties, getActivityLogsResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(activityLogs, pagination);
+    return Objects.hash(activityLogs, pagination, additionalProperties);
   }
 
   @Override
@@ -136,6 +181,7 @@ public class GetActivityLogsResponse {
     sb.append("class GetActivityLogsResponse {\n");
     sb.append("    activityLogs: ").append(toIndentedString(activityLogs)).append("\n");
     sb.append("    pagination: ").append(toIndentedString(pagination)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -180,14 +226,6 @@ public class GetActivityLogsResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!GetActivityLogsResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GetActivityLogsResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : GetActivityLogsResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -224,6 +262,28 @@ public class GetActivityLogsResponse {
            @Override
            public void write(JsonWriter out, GetActivityLogsResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -231,7 +291,28 @@ public class GetActivityLogsResponse {
            public GetActivityLogsResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             GetActivityLogsResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/GetBusinessBankAccountsResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/GetBusinessBankAccountsResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -110,6 +110,50 @@ public class GetBusinessBankAccountsResponse {
     this.pagination = pagination;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the GetBusinessBankAccountsResponse instance itself
+   */
+  public GetBusinessBankAccountsResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -122,12 +166,13 @@ public class GetBusinessBankAccountsResponse {
     }
     GetBusinessBankAccountsResponse getBusinessBankAccountsResponse = (GetBusinessBankAccountsResponse) o;
     return Objects.equals(this.bankAccounts, getBusinessBankAccountsResponse.bankAccounts) &&
-        Objects.equals(this.pagination, getBusinessBankAccountsResponse.pagination);
+        Objects.equals(this.pagination, getBusinessBankAccountsResponse.pagination)&&
+        Objects.equals(this.additionalProperties, getBusinessBankAccountsResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bankAccounts, pagination);
+    return Objects.hash(bankAccounts, pagination, additionalProperties);
   }
 
   @Override
@@ -136,6 +181,7 @@ public class GetBusinessBankAccountsResponse {
     sb.append("class GetBusinessBankAccountsResponse {\n");
     sb.append("    bankAccounts: ").append(toIndentedString(bankAccounts)).append("\n");
     sb.append("    pagination: ").append(toIndentedString(pagination)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -180,14 +226,6 @@ public class GetBusinessBankAccountsResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!GetBusinessBankAccountsResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GetBusinessBankAccountsResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : GetBusinessBankAccountsResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -224,6 +262,28 @@ public class GetBusinessBankAccountsResponse {
            @Override
            public void write(JsonWriter out, GetBusinessBankAccountsResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -231,7 +291,28 @@ public class GetBusinessBankAccountsResponse {
            public GetBusinessBankAccountsResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             GetBusinessBankAccountsResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/GetBusinessesResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/GetBusinessesResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -110,6 +110,50 @@ public class GetBusinessesResponse {
     this.pagination = pagination;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the GetBusinessesResponse instance itself
+   */
+  public GetBusinessesResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -122,12 +166,13 @@ public class GetBusinessesResponse {
     }
     GetBusinessesResponse getBusinessesResponse = (GetBusinessesResponse) o;
     return Objects.equals(this.businesses, getBusinessesResponse.businesses) &&
-        Objects.equals(this.pagination, getBusinessesResponse.pagination);
+        Objects.equals(this.pagination, getBusinessesResponse.pagination)&&
+        Objects.equals(this.additionalProperties, getBusinessesResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(businesses, pagination);
+    return Objects.hash(businesses, pagination, additionalProperties);
   }
 
   @Override
@@ -136,6 +181,7 @@ public class GetBusinessesResponse {
     sb.append("class GetBusinessesResponse {\n");
     sb.append("    businesses: ").append(toIndentedString(businesses)).append("\n");
     sb.append("    pagination: ").append(toIndentedString(pagination)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -180,14 +226,6 @@ public class GetBusinessesResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!GetBusinessesResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GetBusinessesResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : GetBusinessesResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -224,6 +262,28 @@ public class GetBusinessesResponse {
            @Override
            public void write(JsonWriter out, GetBusinessesResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -231,7 +291,28 @@ public class GetBusinessesResponse {
            public GetBusinessesResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             GetBusinessesResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/GetDrawRequestsResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/GetDrawRequestsResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -110,6 +110,50 @@ public class GetDrawRequestsResponse {
     this.pagination = pagination;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the GetDrawRequestsResponse instance itself
+   */
+  public GetDrawRequestsResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -122,12 +166,13 @@ public class GetDrawRequestsResponse {
     }
     GetDrawRequestsResponse getDrawRequestsResponse = (GetDrawRequestsResponse) o;
     return Objects.equals(this.drawRequests, getDrawRequestsResponse.drawRequests) &&
-        Objects.equals(this.pagination, getDrawRequestsResponse.pagination);
+        Objects.equals(this.pagination, getDrawRequestsResponse.pagination)&&
+        Objects.equals(this.additionalProperties, getDrawRequestsResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(drawRequests, pagination);
+    return Objects.hash(drawRequests, pagination, additionalProperties);
   }
 
   @Override
@@ -136,6 +181,7 @@ public class GetDrawRequestsResponse {
     sb.append("class GetDrawRequestsResponse {\n");
     sb.append("    drawRequests: ").append(toIndentedString(drawRequests)).append("\n");
     sb.append("    pagination: ").append(toIndentedString(pagination)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -180,14 +226,6 @@ public class GetDrawRequestsResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!GetDrawRequestsResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GetDrawRequestsResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : GetDrawRequestsResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -224,6 +262,28 @@ public class GetDrawRequestsResponse {
            @Override
            public void write(JsonWriter out, GetDrawRequestsResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -231,7 +291,28 @@ public class GetDrawRequestsResponse {
            public GetDrawRequestsResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             GetDrawRequestsResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/GetIntegratedMcaPaymentWindowsResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/GetIntegratedMcaPaymentWindowsResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -86,6 +86,50 @@ public class GetIntegratedMcaPaymentWindowsResponse {
     this.paymentWindows = paymentWindows;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the GetIntegratedMcaPaymentWindowsResponse instance itself
+   */
+  public GetIntegratedMcaPaymentWindowsResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -97,12 +141,13 @@ public class GetIntegratedMcaPaymentWindowsResponse {
       return false;
     }
     GetIntegratedMcaPaymentWindowsResponse getIntegratedMcaPaymentWindowsResponse = (GetIntegratedMcaPaymentWindowsResponse) o;
-    return Objects.equals(this.paymentWindows, getIntegratedMcaPaymentWindowsResponse.paymentWindows);
+    return Objects.equals(this.paymentWindows, getIntegratedMcaPaymentWindowsResponse.paymentWindows)&&
+        Objects.equals(this.additionalProperties, getIntegratedMcaPaymentWindowsResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(paymentWindows);
+    return Objects.hash(paymentWindows, additionalProperties);
   }
 
   @Override
@@ -110,6 +155,7 @@ public class GetIntegratedMcaPaymentWindowsResponse {
     StringBuilder sb = new StringBuilder();
     sb.append("class GetIntegratedMcaPaymentWindowsResponse {\n");
     sb.append("    paymentWindows: ").append(toIndentedString(paymentWindows)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -152,14 +198,6 @@ public class GetIntegratedMcaPaymentWindowsResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!GetIntegratedMcaPaymentWindowsResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GetIntegratedMcaPaymentWindowsResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : GetIntegratedMcaPaymentWindowsResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -194,6 +232,28 @@ public class GetIntegratedMcaPaymentWindowsResponse {
            @Override
            public void write(JsonWriter out, GetIntegratedMcaPaymentWindowsResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -201,7 +261,28 @@ public class GetIntegratedMcaPaymentWindowsResponse {
            public GetIntegratedMcaPaymentWindowsResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             GetIntegratedMcaPaymentWindowsResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/GetIntegratedMcaReceivablesResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/GetIntegratedMcaReceivablesResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -110,6 +110,50 @@ public class GetIntegratedMcaReceivablesResponse {
     this.pagination = pagination;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the GetIntegratedMcaReceivablesResponse instance itself
+   */
+  public GetIntegratedMcaReceivablesResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -122,12 +166,13 @@ public class GetIntegratedMcaReceivablesResponse {
     }
     GetIntegratedMcaReceivablesResponse getIntegratedMcaReceivablesResponse = (GetIntegratedMcaReceivablesResponse) o;
     return Objects.equals(this.integratedMcaReceivables, getIntegratedMcaReceivablesResponse.integratedMcaReceivables) &&
-        Objects.equals(this.pagination, getIntegratedMcaReceivablesResponse.pagination);
+        Objects.equals(this.pagination, getIntegratedMcaReceivablesResponse.pagination)&&
+        Objects.equals(this.additionalProperties, getIntegratedMcaReceivablesResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integratedMcaReceivables, pagination);
+    return Objects.hash(integratedMcaReceivables, pagination, additionalProperties);
   }
 
   @Override
@@ -136,6 +181,7 @@ public class GetIntegratedMcaReceivablesResponse {
     sb.append("class GetIntegratedMcaReceivablesResponse {\n");
     sb.append("    integratedMcaReceivables: ").append(toIndentedString(integratedMcaReceivables)).append("\n");
     sb.append("    pagination: ").append(toIndentedString(pagination)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -180,14 +226,6 @@ public class GetIntegratedMcaReceivablesResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!GetIntegratedMcaReceivablesResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GetIntegratedMcaReceivablesResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : GetIntegratedMcaReceivablesResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -224,6 +262,28 @@ public class GetIntegratedMcaReceivablesResponse {
            @Override
            public void write(JsonWriter out, GetIntegratedMcaReceivablesResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -231,7 +291,28 @@ public class GetIntegratedMcaReceivablesResponse {
            public GetIntegratedMcaReceivablesResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             GetIntegratedMcaReceivablesResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/GetInvoice404Response.java
+++ b/java/src/main/java/com/kanmon/client/model/GetInvoice404Response.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/GetInvoicesResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/GetInvoicesResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -110,6 +110,50 @@ public class GetInvoicesResponse {
     this.pagination = pagination;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the GetInvoicesResponse instance itself
+   */
+  public GetInvoicesResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -122,12 +166,13 @@ public class GetInvoicesResponse {
     }
     GetInvoicesResponse getInvoicesResponse = (GetInvoicesResponse) o;
     return Objects.equals(this.invoices, getInvoicesResponse.invoices) &&
-        Objects.equals(this.pagination, getInvoicesResponse.pagination);
+        Objects.equals(this.pagination, getInvoicesResponse.pagination)&&
+        Objects.equals(this.additionalProperties, getInvoicesResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(invoices, pagination);
+    return Objects.hash(invoices, pagination, additionalProperties);
   }
 
   @Override
@@ -136,6 +181,7 @@ public class GetInvoicesResponse {
     sb.append("class GetInvoicesResponse {\n");
     sb.append("    invoices: ").append(toIndentedString(invoices)).append("\n");
     sb.append("    pagination: ").append(toIndentedString(pagination)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -180,14 +226,6 @@ public class GetInvoicesResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!GetInvoicesResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GetInvoicesResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : GetInvoicesResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -224,6 +262,28 @@ public class GetInvoicesResponse {
            @Override
            public void write(JsonWriter out, GetInvoicesResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -231,7 +291,28 @@ public class GetInvoicesResponse {
            public GetInvoicesResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             GetInvoicesResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/GetIssuedProductsResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/GetIssuedProductsResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -110,6 +110,50 @@ public class GetIssuedProductsResponse {
     this.pagination = pagination;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the GetIssuedProductsResponse instance itself
+   */
+  public GetIssuedProductsResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -122,12 +166,13 @@ public class GetIssuedProductsResponse {
     }
     GetIssuedProductsResponse getIssuedProductsResponse = (GetIssuedProductsResponse) o;
     return Objects.equals(this.issuedProducts, getIssuedProductsResponse.issuedProducts) &&
-        Objects.equals(this.pagination, getIssuedProductsResponse.pagination);
+        Objects.equals(this.pagination, getIssuedProductsResponse.pagination)&&
+        Objects.equals(this.additionalProperties, getIssuedProductsResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(issuedProducts, pagination);
+    return Objects.hash(issuedProducts, pagination, additionalProperties);
   }
 
   @Override
@@ -136,6 +181,7 @@ public class GetIssuedProductsResponse {
     sb.append("class GetIssuedProductsResponse {\n");
     sb.append("    issuedProducts: ").append(toIndentedString(issuedProducts)).append("\n");
     sb.append("    pagination: ").append(toIndentedString(pagination)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -180,14 +226,6 @@ public class GetIssuedProductsResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!GetIssuedProductsResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GetIssuedProductsResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : GetIssuedProductsResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -224,6 +262,28 @@ public class GetIssuedProductsResponse {
            @Override
            public void write(JsonWriter out, GetIssuedProductsResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -231,7 +291,28 @@ public class GetIssuedProductsResponse {
            public GetIssuedProductsResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             GetIssuedProductsResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/GetOffersResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/GetOffersResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -110,6 +110,50 @@ public class GetOffersResponse {
     this.pagination = pagination;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the GetOffersResponse instance itself
+   */
+  public GetOffersResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -122,12 +166,13 @@ public class GetOffersResponse {
     }
     GetOffersResponse getOffersResponse = (GetOffersResponse) o;
     return Objects.equals(this.offers, getOffersResponse.offers) &&
-        Objects.equals(this.pagination, getOffersResponse.pagination);
+        Objects.equals(this.pagination, getOffersResponse.pagination)&&
+        Objects.equals(this.additionalProperties, getOffersResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(offers, pagination);
+    return Objects.hash(offers, pagination, additionalProperties);
   }
 
   @Override
@@ -136,6 +181,7 @@ public class GetOffersResponse {
     sb.append("class GetOffersResponse {\n");
     sb.append("    offers: ").append(toIndentedString(offers)).append("\n");
     sb.append("    pagination: ").append(toIndentedString(pagination)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -180,14 +226,6 @@ public class GetOffersResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!GetOffersResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GetOffersResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : GetOffersResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -224,6 +262,28 @@ public class GetOffersResponse {
            @Override
            public void write(JsonWriter out, GetOffersResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -231,7 +291,28 @@ public class GetOffersResponse {
            public GetOffersResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             GetOffersResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/GetPaymentScheduleResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/GetPaymentScheduleResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -110,6 +110,50 @@ public class GetPaymentScheduleResponse {
     this.pagination = pagination;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the GetPaymentScheduleResponse instance itself
+   */
+  public GetPaymentScheduleResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -122,12 +166,13 @@ public class GetPaymentScheduleResponse {
     }
     GetPaymentScheduleResponse getPaymentScheduleResponse = (GetPaymentScheduleResponse) o;
     return Objects.equals(this.paymentSchedule, getPaymentScheduleResponse.paymentSchedule) &&
-        Objects.equals(this.pagination, getPaymentScheduleResponse.pagination);
+        Objects.equals(this.pagination, getPaymentScheduleResponse.pagination)&&
+        Objects.equals(this.additionalProperties, getPaymentScheduleResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(paymentSchedule, pagination);
+    return Objects.hash(paymentSchedule, pagination, additionalProperties);
   }
 
   @Override
@@ -136,6 +181,7 @@ public class GetPaymentScheduleResponse {
     sb.append("class GetPaymentScheduleResponse {\n");
     sb.append("    paymentSchedule: ").append(toIndentedString(paymentSchedule)).append("\n");
     sb.append("    pagination: ").append(toIndentedString(pagination)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -180,14 +226,6 @@ public class GetPaymentScheduleResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!GetPaymentScheduleResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GetPaymentScheduleResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : GetPaymentScheduleResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -224,6 +262,28 @@ public class GetPaymentScheduleResponse {
            @Override
            public void write(JsonWriter out, GetPaymentScheduleResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -231,7 +291,28 @@ public class GetPaymentScheduleResponse {
            public GetPaymentScheduleResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             GetPaymentScheduleResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/GetPrequalificationsResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/GetPrequalificationsResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -110,6 +110,50 @@ public class GetPrequalificationsResponse {
     this.pagination = pagination;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the GetPrequalificationsResponse instance itself
+   */
+  public GetPrequalificationsResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -122,12 +166,13 @@ public class GetPrequalificationsResponse {
     }
     GetPrequalificationsResponse getPrequalificationsResponse = (GetPrequalificationsResponse) o;
     return Objects.equals(this.prequalifications, getPrequalificationsResponse.prequalifications) &&
-        Objects.equals(this.pagination, getPrequalificationsResponse.pagination);
+        Objects.equals(this.pagination, getPrequalificationsResponse.pagination)&&
+        Objects.equals(this.additionalProperties, getPrequalificationsResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(prequalifications, pagination);
+    return Objects.hash(prequalifications, pagination, additionalProperties);
   }
 
   @Override
@@ -136,6 +181,7 @@ public class GetPrequalificationsResponse {
     sb.append("class GetPrequalificationsResponse {\n");
     sb.append("    prequalifications: ").append(toIndentedString(prequalifications)).append("\n");
     sb.append("    pagination: ").append(toIndentedString(pagination)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -180,14 +226,6 @@ public class GetPrequalificationsResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!GetPrequalificationsResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GetPrequalificationsResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : GetPrequalificationsResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -224,6 +262,28 @@ public class GetPrequalificationsResponse {
            @Override
            public void write(JsonWriter out, GetPrequalificationsResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -231,7 +291,28 @@ public class GetPrequalificationsResponse {
            public GetPrequalificationsResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             GetPrequalificationsResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/GetUsersResponse.java
+++ b/java/src/main/java/com/kanmon/client/model/GetUsersResponse.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -110,6 +110,50 @@ public class GetUsersResponse {
     this.pagination = pagination;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the GetUsersResponse instance itself
+   */
+  public GetUsersResponse putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -122,12 +166,13 @@ public class GetUsersResponse {
     }
     GetUsersResponse getUsersResponse = (GetUsersResponse) o;
     return Objects.equals(this.users, getUsersResponse.users) &&
-        Objects.equals(this.pagination, getUsersResponse.pagination);
+        Objects.equals(this.pagination, getUsersResponse.pagination)&&
+        Objects.equals(this.additionalProperties, getUsersResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(users, pagination);
+    return Objects.hash(users, pagination, additionalProperties);
   }
 
   @Override
@@ -136,6 +181,7 @@ public class GetUsersResponse {
     sb.append("class GetUsersResponse {\n");
     sb.append("    users: ").append(toIndentedString(users)).append("\n");
     sb.append("    pagination: ").append(toIndentedString(pagination)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -180,14 +226,6 @@ public class GetUsersResponse {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!GetUsersResponse.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `GetUsersResponse` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : GetUsersResponse.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -224,6 +262,28 @@ public class GetUsersResponse {
            @Override
            public void write(JsonWriter out, GetUsersResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -231,7 +291,28 @@ public class GetUsersResponse {
            public GetUsersResponse read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             GetUsersResponse instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/IncorrectFinancingAmountException.java
+++ b/java/src/main/java/com/kanmon/client/model/IncorrectFinancingAmountException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class IncorrectFinancingAmountException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IncorrectFinancingAmountException instance itself
+   */
+  public IncorrectFinancingAmountException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class IncorrectFinancingAmountException {
     IncorrectFinancingAmountException incorrectFinancingAmountException = (IncorrectFinancingAmountException) o;
     return Objects.equals(this.errorCode, incorrectFinancingAmountException.errorCode) &&
         Objects.equals(this.message, incorrectFinancingAmountException.message) &&
-        Objects.equals(this.timestamp, incorrectFinancingAmountException.timestamp);
+        Objects.equals(this.timestamp, incorrectFinancingAmountException.timestamp)&&
+        Objects.equals(this.additionalProperties, incorrectFinancingAmountException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class IncorrectFinancingAmountException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class IncorrectFinancingAmountException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IncorrectFinancingAmountException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IncorrectFinancingAmountException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IncorrectFinancingAmountException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class IncorrectFinancingAmountException {
            @Override
            public void write(JsonWriter out, IncorrectFinancingAmountException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class IncorrectFinancingAmountException {
            public IncorrectFinancingAmountException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IncorrectFinancingAmountException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/IncorrectProductTypeException.java
+++ b/java/src/main/java/com/kanmon/client/model/IncorrectProductTypeException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class IncorrectProductTypeException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IncorrectProductTypeException instance itself
+   */
+  public IncorrectProductTypeException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class IncorrectProductTypeException {
     IncorrectProductTypeException incorrectProductTypeException = (IncorrectProductTypeException) o;
     return Objects.equals(this.errorCode, incorrectProductTypeException.errorCode) &&
         Objects.equals(this.message, incorrectProductTypeException.message) &&
-        Objects.equals(this.timestamp, incorrectProductTypeException.timestamp);
+        Objects.equals(this.timestamp, incorrectProductTypeException.timestamp)&&
+        Objects.equals(this.additionalProperties, incorrectProductTypeException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class IncorrectProductTypeException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class IncorrectProductTypeException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IncorrectProductTypeException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IncorrectProductTypeException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IncorrectProductTypeException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class IncorrectProductTypeException {
            @Override
            public void write(JsonWriter out, IncorrectProductTypeException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class IncorrectProductTypeException {
            public IncorrectProductTypeException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IncorrectProductTypeException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/IncorrectRepaymentAmountException.java
+++ b/java/src/main/java/com/kanmon/client/model/IncorrectRepaymentAmountException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class IncorrectRepaymentAmountException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IncorrectRepaymentAmountException instance itself
+   */
+  public IncorrectRepaymentAmountException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class IncorrectRepaymentAmountException {
     IncorrectRepaymentAmountException incorrectRepaymentAmountException = (IncorrectRepaymentAmountException) o;
     return Objects.equals(this.errorCode, incorrectRepaymentAmountException.errorCode) &&
         Objects.equals(this.message, incorrectRepaymentAmountException.message) &&
-        Objects.equals(this.timestamp, incorrectRepaymentAmountException.timestamp);
+        Objects.equals(this.timestamp, incorrectRepaymentAmountException.timestamp)&&
+        Objects.equals(this.additionalProperties, incorrectRepaymentAmountException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class IncorrectRepaymentAmountException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class IncorrectRepaymentAmountException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IncorrectRepaymentAmountException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IncorrectRepaymentAmountException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IncorrectRepaymentAmountException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class IncorrectRepaymentAmountException {
            @Override
            public void write(JsonWriter out, IncorrectRepaymentAmountException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class IncorrectRepaymentAmountException {
            public IncorrectRepaymentAmountException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IncorrectRepaymentAmountException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InsufficientCreditLimitException.java
+++ b/java/src/main/java/com/kanmon/client/model/InsufficientCreditLimitException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class InsufficientCreditLimitException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the InsufficientCreditLimitException instance itself
+   */
+  public InsufficientCreditLimitException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class InsufficientCreditLimitException {
     InsufficientCreditLimitException insufficientCreditLimitException = (InsufficientCreditLimitException) o;
     return Objects.equals(this.errorCode, insufficientCreditLimitException.errorCode) &&
         Objects.equals(this.message, insufficientCreditLimitException.message) &&
-        Objects.equals(this.timestamp, insufficientCreditLimitException.timestamp);
+        Objects.equals(this.timestamp, insufficientCreditLimitException.timestamp)&&
+        Objects.equals(this.additionalProperties, insufficientCreditLimitException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class InsufficientCreditLimitException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class InsufficientCreditLimitException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!InsufficientCreditLimitException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InsufficientCreditLimitException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InsufficientCreditLimitException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class InsufficientCreditLimitException {
            @Override
            public void write(JsonWriter out, InsufficientCreditLimitException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class InsufficientCreditLimitException {
            public InsufficientCreditLimitException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             InsufficientCreditLimitException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/IntegratedMcaOfferTerms.java
+++ b/java/src/main/java/com/kanmon/client/model/IntegratedMcaOfferTerms.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -238,6 +238,50 @@ public class IntegratedMcaOfferTerms {
     this.feeAmountCents = feeAmountCents;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IntegratedMcaOfferTerms instance itself
+   */
+  public IntegratedMcaOfferTerms putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -256,12 +300,13 @@ public class IntegratedMcaOfferTerms {
         Objects.equals(this.totalRepaymentCents, integratedMcaOfferTerms.totalRepaymentCents) &&
         Objects.equals(this.maxAdvanceAmountCents, integratedMcaOfferTerms.maxAdvanceAmountCents) &&
         Objects.equals(this.monthlyMinimumPaymentAmountCents, integratedMcaOfferTerms.monthlyMinimumPaymentAmountCents) &&
-        Objects.equals(this.feeAmountCents, integratedMcaOfferTerms.feeAmountCents);
+        Objects.equals(this.feeAmountCents, integratedMcaOfferTerms.feeAmountCents)&&
+        Objects.equals(this.additionalProperties, integratedMcaOfferTerms.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productType, advanceAmountCents, repaymentPercentage, feeFactor, totalRepaymentCents, maxAdvanceAmountCents, monthlyMinimumPaymentAmountCents, feeAmountCents);
+    return Objects.hash(productType, advanceAmountCents, repaymentPercentage, feeFactor, totalRepaymentCents, maxAdvanceAmountCents, monthlyMinimumPaymentAmountCents, feeAmountCents, additionalProperties);
   }
 
   @Override
@@ -276,6 +321,7 @@ public class IntegratedMcaOfferTerms {
     sb.append("    maxAdvanceAmountCents: ").append(toIndentedString(maxAdvanceAmountCents)).append("\n");
     sb.append("    monthlyMinimumPaymentAmountCents: ").append(toIndentedString(monthlyMinimumPaymentAmountCents)).append("\n");
     sb.append("    feeAmountCents: ").append(toIndentedString(feeAmountCents)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -332,14 +378,6 @@ public class IntegratedMcaOfferTerms {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IntegratedMcaOfferTerms.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IntegratedMcaOfferTerms` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IntegratedMcaOfferTerms.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -366,6 +404,28 @@ public class IntegratedMcaOfferTerms {
            @Override
            public void write(JsonWriter out, IntegratedMcaOfferTerms value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -373,7 +433,28 @@ public class IntegratedMcaOfferTerms {
            public IntegratedMcaOfferTerms read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IntegratedMcaOfferTerms instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/IntegratedMcaPaymentWindow.java
+++ b/java/src/main/java/com/kanmon/client/model/IntegratedMcaPaymentWindow.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -145,6 +145,50 @@ public class IntegratedMcaPaymentWindow {
     this.minimumPaymentAmountCentsInWindow = minimumPaymentAmountCentsInWindow;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IntegratedMcaPaymentWindow instance itself
+   */
+  public IntegratedMcaPaymentWindow putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -159,12 +203,13 @@ public class IntegratedMcaPaymentWindow {
     return Objects.equals(this.windowStartDate, integratedMcaPaymentWindow.windowStartDate) &&
         Objects.equals(this.windowEndDate, integratedMcaPaymentWindow.windowEndDate) &&
         Objects.equals(this.totalRepaymentAmountCentsInWindow, integratedMcaPaymentWindow.totalRepaymentAmountCentsInWindow) &&
-        Objects.equals(this.minimumPaymentAmountCentsInWindow, integratedMcaPaymentWindow.minimumPaymentAmountCentsInWindow);
+        Objects.equals(this.minimumPaymentAmountCentsInWindow, integratedMcaPaymentWindow.minimumPaymentAmountCentsInWindow)&&
+        Objects.equals(this.additionalProperties, integratedMcaPaymentWindow.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(windowStartDate, windowEndDate, totalRepaymentAmountCentsInWindow, minimumPaymentAmountCentsInWindow);
+    return Objects.hash(windowStartDate, windowEndDate, totalRepaymentAmountCentsInWindow, minimumPaymentAmountCentsInWindow, additionalProperties);
   }
 
   @Override
@@ -175,6 +220,7 @@ public class IntegratedMcaPaymentWindow {
     sb.append("    windowEndDate: ").append(toIndentedString(windowEndDate)).append("\n");
     sb.append("    totalRepaymentAmountCentsInWindow: ").append(toIndentedString(totalRepaymentAmountCentsInWindow)).append("\n");
     sb.append("    minimumPaymentAmountCentsInWindow: ").append(toIndentedString(minimumPaymentAmountCentsInWindow)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -223,14 +269,6 @@ public class IntegratedMcaPaymentWindow {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IntegratedMcaPaymentWindow.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IntegratedMcaPaymentWindow` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IntegratedMcaPaymentWindow.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -261,6 +299,28 @@ public class IntegratedMcaPaymentWindow {
            @Override
            public void write(JsonWriter out, IntegratedMcaPaymentWindow value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -268,7 +328,28 @@ public class IntegratedMcaPaymentWindow {
            public IntegratedMcaPaymentWindow read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IntegratedMcaPaymentWindow instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/IntegratedMcaReceivable.java
+++ b/java/src/main/java/com/kanmon/client/model/IntegratedMcaReceivable.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -237,6 +237,50 @@ public class IntegratedMcaReceivable {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IntegratedMcaReceivable instance itself
+   */
+  public IntegratedMcaReceivable putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -255,12 +299,13 @@ public class IntegratedMcaReceivable {
         Objects.equals(this.transactionId, integratedMcaReceivable.transactionId) &&
         Objects.equals(this.transactionTime, integratedMcaReceivable.transactionTime) &&
         Objects.equals(this.createdAt, integratedMcaReceivable.createdAt) &&
-        Objects.equals(this.updatedAt, integratedMcaReceivable.updatedAt);
+        Objects.equals(this.updatedAt, integratedMcaReceivable.updatedAt)&&
+        Objects.equals(this.additionalProperties, integratedMcaReceivable.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, issuedProductId, chargeAmountCents, repaymentAmountCents, transactionId, transactionTime, createdAt, updatedAt);
+    return Objects.hash(id, issuedProductId, chargeAmountCents, repaymentAmountCents, transactionId, transactionTime, createdAt, updatedAt, additionalProperties);
   }
 
   @Override
@@ -275,6 +320,7 @@ public class IntegratedMcaReceivable {
     sb.append("    transactionTime: ").append(toIndentedString(transactionTime)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -331,14 +377,6 @@ public class IntegratedMcaReceivable {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IntegratedMcaReceivable.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IntegratedMcaReceivable` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IntegratedMcaReceivable.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -381,6 +419,28 @@ public class IntegratedMcaReceivable {
            @Override
            public void write(JsonWriter out, IntegratedMcaReceivable value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -388,7 +448,28 @@ public class IntegratedMcaReceivable {
            public IntegratedMcaReceivable read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IntegratedMcaReceivable instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/IntegratedMcaReceivableAlreadyExistsException.java
+++ b/java/src/main/java/com/kanmon/client/model/IntegratedMcaReceivableAlreadyExistsException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class IntegratedMcaReceivableAlreadyExistsException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IntegratedMcaReceivableAlreadyExistsException instance itself
+   */
+  public IntegratedMcaReceivableAlreadyExistsException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class IntegratedMcaReceivableAlreadyExistsException {
     IntegratedMcaReceivableAlreadyExistsException integratedMcaReceivableAlreadyExistsException = (IntegratedMcaReceivableAlreadyExistsException) o;
     return Objects.equals(this.errorCode, integratedMcaReceivableAlreadyExistsException.errorCode) &&
         Objects.equals(this.message, integratedMcaReceivableAlreadyExistsException.message) &&
-        Objects.equals(this.timestamp, integratedMcaReceivableAlreadyExistsException.timestamp);
+        Objects.equals(this.timestamp, integratedMcaReceivableAlreadyExistsException.timestamp)&&
+        Objects.equals(this.additionalProperties, integratedMcaReceivableAlreadyExistsException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class IntegratedMcaReceivableAlreadyExistsException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class IntegratedMcaReceivableAlreadyExistsException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IntegratedMcaReceivableAlreadyExistsException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IntegratedMcaReceivableAlreadyExistsException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IntegratedMcaReceivableAlreadyExistsException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class IntegratedMcaReceivableAlreadyExistsException {
            @Override
            public void write(JsonWriter out, IntegratedMcaReceivableAlreadyExistsException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class IntegratedMcaReceivableAlreadyExistsException {
            public IntegratedMcaReceivableAlreadyExistsException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IntegratedMcaReceivableAlreadyExistsException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/IntegratedMcaServicingData.java
+++ b/java/src/main/java/com/kanmon/client/model/IntegratedMcaServicingData.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -238,6 +238,50 @@ public class IntegratedMcaServicingData {
     this.feeAmountCents = feeAmountCents;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IntegratedMcaServicingData instance itself
+   */
+  public IntegratedMcaServicingData putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -256,12 +300,13 @@ public class IntegratedMcaServicingData {
         Objects.equals(this.totalRepaymentCents, integratedMcaServicingData.totalRepaymentCents) &&
         Objects.equals(this.advanceBalanceCents, integratedMcaServicingData.advanceBalanceCents) &&
         Objects.equals(this.monthlyMinimumPaymentAmountCents, integratedMcaServicingData.monthlyMinimumPaymentAmountCents) &&
-        Objects.equals(this.feeAmountCents, integratedMcaServicingData.feeAmountCents);
+        Objects.equals(this.feeAmountCents, integratedMcaServicingData.feeAmountCents)&&
+        Objects.equals(this.additionalProperties, integratedMcaServicingData.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productType, advanceAmountCents, repaymentPercentage, feeFactor, totalRepaymentCents, advanceBalanceCents, monthlyMinimumPaymentAmountCents, feeAmountCents);
+    return Objects.hash(productType, advanceAmountCents, repaymentPercentage, feeFactor, totalRepaymentCents, advanceBalanceCents, monthlyMinimumPaymentAmountCents, feeAmountCents, additionalProperties);
   }
 
   @Override
@@ -276,6 +321,7 @@ public class IntegratedMcaServicingData {
     sb.append("    advanceBalanceCents: ").append(toIndentedString(advanceBalanceCents)).append("\n");
     sb.append("    monthlyMinimumPaymentAmountCents: ").append(toIndentedString(monthlyMinimumPaymentAmountCents)).append("\n");
     sb.append("    feeAmountCents: ").append(toIndentedString(feeAmountCents)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -332,14 +378,6 @@ public class IntegratedMcaServicingData {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IntegratedMcaServicingData.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IntegratedMcaServicingData` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IntegratedMcaServicingData.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -366,6 +404,28 @@ public class IntegratedMcaServicingData {
            @Override
            public void write(JsonWriter out, IntegratedMcaServicingData value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -373,7 +433,28 @@ public class IntegratedMcaServicingData {
            public IntegratedMcaServicingData read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IntegratedMcaServicingData instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InternalServerErrorException.java
+++ b/java/src/main/java/com/kanmon/client/model/InternalServerErrorException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class InternalServerErrorException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the InternalServerErrorException instance itself
+   */
+  public InternalServerErrorException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class InternalServerErrorException {
     InternalServerErrorException internalServerErrorException = (InternalServerErrorException) o;
     return Objects.equals(this.errorCode, internalServerErrorException.errorCode) &&
         Objects.equals(this.message, internalServerErrorException.message) &&
-        Objects.equals(this.timestamp, internalServerErrorException.timestamp);
+        Objects.equals(this.timestamp, internalServerErrorException.timestamp)&&
+        Objects.equals(this.additionalProperties, internalServerErrorException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class InternalServerErrorException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class InternalServerErrorException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!InternalServerErrorException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InternalServerErrorException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InternalServerErrorException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class InternalServerErrorException {
            @Override
            public void write(JsonWriter out, InternalServerErrorException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class InternalServerErrorException {
            public InternalServerErrorException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             InternalServerErrorException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InvalidInvoiceDueDateException.java
+++ b/java/src/main/java/com/kanmon/client/model/InvalidInvoiceDueDateException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class InvalidInvoiceDueDateException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the InvalidInvoiceDueDateException instance itself
+   */
+  public InvalidInvoiceDueDateException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class InvalidInvoiceDueDateException {
     InvalidInvoiceDueDateException invalidInvoiceDueDateException = (InvalidInvoiceDueDateException) o;
     return Objects.equals(this.errorCode, invalidInvoiceDueDateException.errorCode) &&
         Objects.equals(this.message, invalidInvoiceDueDateException.message) &&
-        Objects.equals(this.timestamp, invalidInvoiceDueDateException.timestamp);
+        Objects.equals(this.timestamp, invalidInvoiceDueDateException.timestamp)&&
+        Objects.equals(this.additionalProperties, invalidInvoiceDueDateException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class InvalidInvoiceDueDateException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class InvalidInvoiceDueDateException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!InvalidInvoiceDueDateException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InvalidInvoiceDueDateException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InvalidInvoiceDueDateException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class InvalidInvoiceDueDateException {
            @Override
            public void write(JsonWriter out, InvalidInvoiceDueDateException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class InvalidInvoiceDueDateException {
            public InvalidInvoiceDueDateException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             InvalidInvoiceDueDateException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/Invoice.java
+++ b/java/src/main/java/com/kanmon/client/model/Invoice.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -897,6 +897,50 @@ public class Invoice {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the Invoice instance itself
+   */
+  public Invoice putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -939,7 +983,8 @@ public class Invoice {
         Objects.equals(this.transactionFeePercentage, invoice.transactionFeePercentage) &&
         Objects.equals(this.amountRequestedForFinancingCents, invoice.amountRequestedForFinancingCents) &&
         Objects.equals(this.createdAt, invoice.createdAt) &&
-        Objects.equals(this.updatedAt, invoice.updatedAt);
+        Objects.equals(this.updatedAt, invoice.updatedAt)&&
+        Objects.equals(this.additionalProperties, invoice.additionalProperties);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -948,7 +993,7 @@ public class Invoice {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, platformInvoiceId, platformInvoiceNumber, invoiceAmountCents, invoiceDueDate, invoiceIssuedDate, payorEmail, payorAddress, payorType, payorBusinessName, payorFirstName, payorMiddleName, payorLastName, payeeEmail, payeeAddress, payeeType, payeeBusinessName, payeeFirstName, payeeMiddleName, payeeLastName, status, issuedProductId, feeAmountCents, principalAmountCents, invoiceAdvanceAmountCents, repaymentAmountCents, repaymentSchedule, advanceRatePercentage, transactionFeePercentage, amountRequestedForFinancingCents, createdAt, updatedAt);
+    return Objects.hash(id, platformInvoiceId, platformInvoiceNumber, invoiceAmountCents, invoiceDueDate, invoiceIssuedDate, payorEmail, payorAddress, payorType, payorBusinessName, payorFirstName, payorMiddleName, payorLastName, payeeEmail, payeeAddress, payeeType, payeeBusinessName, payeeFirstName, payeeMiddleName, payeeLastName, status, issuedProductId, feeAmountCents, principalAmountCents, invoiceAdvanceAmountCents, repaymentAmountCents, repaymentSchedule, advanceRatePercentage, transactionFeePercentage, amountRequestedForFinancingCents, createdAt, updatedAt, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -994,6 +1039,7 @@ public class Invoice {
     sb.append("    amountRequestedForFinancingCents: ").append(toIndentedString(amountRequestedForFinancingCents)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -1091,14 +1137,6 @@ public class Invoice {
       if (jsonElement == null) {
         if (!Invoice.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
           throw new IllegalArgumentException(String.format("The required field(s) %s in Invoice is not found in the empty JSON string", Invoice.openapiRequiredFields.toString()));
-        }
-      }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!Invoice.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Invoice` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
         }
       }
 
@@ -1206,6 +1244,28 @@ public class Invoice {
            @Override
            public void write(JsonWriter out, Invoice value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -1213,7 +1273,28 @@ public class Invoice {
            public Invoice read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             Invoice instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InvoiceFinancingOfferTerms.java
+++ b/java/src/main/java/com/kanmon/client/model/InvoiceFinancingOfferTerms.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -134,6 +134,50 @@ public class InvoiceFinancingOfferTerms {
     this.pricingPlans = pricingPlans;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the InvoiceFinancingOfferTerms instance itself
+   */
+  public InvoiceFinancingOfferTerms putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -147,12 +191,13 @@ public class InvoiceFinancingOfferTerms {
     InvoiceFinancingOfferTerms invoiceFinancingOfferTerms = (InvoiceFinancingOfferTerms) o;
     return Objects.equals(this.productType, invoiceFinancingOfferTerms.productType) &&
         Objects.equals(this.totalLimitCents, invoiceFinancingOfferTerms.totalLimitCents) &&
-        Objects.equals(this.pricingPlans, invoiceFinancingOfferTerms.pricingPlans);
+        Objects.equals(this.pricingPlans, invoiceFinancingOfferTerms.pricingPlans)&&
+        Objects.equals(this.additionalProperties, invoiceFinancingOfferTerms.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productType, totalLimitCents, pricingPlans);
+    return Objects.hash(productType, totalLimitCents, pricingPlans, additionalProperties);
   }
 
   @Override
@@ -162,6 +207,7 @@ public class InvoiceFinancingOfferTerms {
     sb.append("    productType: ").append(toIndentedString(productType)).append("\n");
     sb.append("    totalLimitCents: ").append(toIndentedString(totalLimitCents)).append("\n");
     sb.append("    pricingPlans: ").append(toIndentedString(pricingPlans)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -208,14 +254,6 @@ public class InvoiceFinancingOfferTerms {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!InvoiceFinancingOfferTerms.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InvoiceFinancingOfferTerms` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InvoiceFinancingOfferTerms.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -252,6 +290,28 @@ public class InvoiceFinancingOfferTerms {
            @Override
            public void write(JsonWriter out, InvoiceFinancingOfferTerms value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -259,7 +319,28 @@ public class InvoiceFinancingOfferTerms {
            public InvoiceFinancingOfferTerms read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             InvoiceFinancingOfferTerms instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InvoiceFinancingServicingData.java
+++ b/java/src/main/java/com/kanmon/client/model/InvoiceFinancingServicingData.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -157,6 +157,50 @@ public class InvoiceFinancingServicingData {
     this.availableLimitCents = availableLimitCents;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the InvoiceFinancingServicingData instance itself
+   */
+  public InvoiceFinancingServicingData putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -171,12 +215,13 @@ public class InvoiceFinancingServicingData {
     return Objects.equals(this.productType, invoiceFinancingServicingData.productType) &&
         Objects.equals(this.totalLimitCents, invoiceFinancingServicingData.totalLimitCents) &&
         Objects.equals(this.pricingPlans, invoiceFinancingServicingData.pricingPlans) &&
-        Objects.equals(this.availableLimitCents, invoiceFinancingServicingData.availableLimitCents);
+        Objects.equals(this.availableLimitCents, invoiceFinancingServicingData.availableLimitCents)&&
+        Objects.equals(this.additionalProperties, invoiceFinancingServicingData.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productType, totalLimitCents, pricingPlans, availableLimitCents);
+    return Objects.hash(productType, totalLimitCents, pricingPlans, availableLimitCents, additionalProperties);
   }
 
   @Override
@@ -187,6 +232,7 @@ public class InvoiceFinancingServicingData {
     sb.append("    totalLimitCents: ").append(toIndentedString(totalLimitCents)).append("\n");
     sb.append("    pricingPlans: ").append(toIndentedString(pricingPlans)).append("\n");
     sb.append("    availableLimitCents: ").append(toIndentedString(availableLimitCents)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -235,14 +281,6 @@ public class InvoiceFinancingServicingData {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!InvoiceFinancingServicingData.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InvoiceFinancingServicingData` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InvoiceFinancingServicingData.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -279,6 +317,28 @@ public class InvoiceFinancingServicingData {
            @Override
            public void write(JsonWriter out, InvoiceFinancingServicingData value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -286,7 +346,28 @@ public class InvoiceFinancingServicingData {
            public InvoiceFinancingServicingData read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             InvoiceFinancingServicingData instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InvoiceFlowSessionTokenData.java
+++ b/java/src/main/java/com/kanmon/client/model/InvoiceFlowSessionTokenData.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -159,6 +159,50 @@ public class InvoiceFlowSessionTokenData {
     this.invoices = invoices;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the InvoiceFlowSessionTokenData instance itself
+   */
+  public InvoiceFlowSessionTokenData putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -171,12 +215,13 @@ public class InvoiceFlowSessionTokenData {
     }
     InvoiceFlowSessionTokenData invoiceFlowSessionTokenData = (InvoiceFlowSessionTokenData) o;
     return Objects.equals(this.component, invoiceFlowSessionTokenData.component) &&
-        Objects.equals(this.invoices, invoiceFlowSessionTokenData.invoices);
+        Objects.equals(this.invoices, invoiceFlowSessionTokenData.invoices)&&
+        Objects.equals(this.additionalProperties, invoiceFlowSessionTokenData.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(component, invoices);
+    return Objects.hash(component, invoices, additionalProperties);
   }
 
   @Override
@@ -185,6 +230,7 @@ public class InvoiceFlowSessionTokenData {
     sb.append("class InvoiceFlowSessionTokenData {\n");
     sb.append("    component: ").append(toIndentedString(component)).append("\n");
     sb.append("    invoices: ").append(toIndentedString(invoices)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -229,14 +275,6 @@ public class InvoiceFlowSessionTokenData {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!InvoiceFlowSessionTokenData.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InvoiceFlowSessionTokenData` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InvoiceFlowSessionTokenData.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -276,6 +314,28 @@ public class InvoiceFlowSessionTokenData {
            @Override
            public void write(JsonWriter out, InvoiceFlowSessionTokenData value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -283,7 +343,28 @@ public class InvoiceFlowSessionTokenData {
            public InvoiceFlowSessionTokenData read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             InvoiceFlowSessionTokenData instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InvoiceFlowWithInvoiceFileSessionTokenData.java
+++ b/java/src/main/java/com/kanmon/client/model/InvoiceFlowWithInvoiceFileSessionTokenData.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -159,6 +159,50 @@ public class InvoiceFlowWithInvoiceFileSessionTokenData {
     this.invoices = invoices;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the InvoiceFlowWithInvoiceFileSessionTokenData instance itself
+   */
+  public InvoiceFlowWithInvoiceFileSessionTokenData putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -171,12 +215,13 @@ public class InvoiceFlowWithInvoiceFileSessionTokenData {
     }
     InvoiceFlowWithInvoiceFileSessionTokenData invoiceFlowWithInvoiceFileSessionTokenData = (InvoiceFlowWithInvoiceFileSessionTokenData) o;
     return Objects.equals(this.component, invoiceFlowWithInvoiceFileSessionTokenData.component) &&
-        Objects.equals(this.invoices, invoiceFlowWithInvoiceFileSessionTokenData.invoices);
+        Objects.equals(this.invoices, invoiceFlowWithInvoiceFileSessionTokenData.invoices)&&
+        Objects.equals(this.additionalProperties, invoiceFlowWithInvoiceFileSessionTokenData.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(component, invoices);
+    return Objects.hash(component, invoices, additionalProperties);
   }
 
   @Override
@@ -185,6 +230,7 @@ public class InvoiceFlowWithInvoiceFileSessionTokenData {
     sb.append("class InvoiceFlowWithInvoiceFileSessionTokenData {\n");
     sb.append("    component: ").append(toIndentedString(component)).append("\n");
     sb.append("    invoices: ").append(toIndentedString(invoices)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -229,14 +275,6 @@ public class InvoiceFlowWithInvoiceFileSessionTokenData {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!InvoiceFlowWithInvoiceFileSessionTokenData.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InvoiceFlowWithInvoiceFileSessionTokenData` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InvoiceFlowWithInvoiceFileSessionTokenData.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -276,6 +314,28 @@ public class InvoiceFlowWithInvoiceFileSessionTokenData {
            @Override
            public void write(JsonWriter out, InvoiceFlowWithInvoiceFileSessionTokenData value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -283,7 +343,28 @@ public class InvoiceFlowWithInvoiceFileSessionTokenData {
            public InvoiceFlowWithInvoiceFileSessionTokenData read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             InvoiceFlowWithInvoiceFileSessionTokenData instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InvoiceNotFoundException.java
+++ b/java/src/main/java/com/kanmon/client/model/InvoiceNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class InvoiceNotFoundException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the InvoiceNotFoundException instance itself
+   */
+  public InvoiceNotFoundException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class InvoiceNotFoundException {
     InvoiceNotFoundException invoiceNotFoundException = (InvoiceNotFoundException) o;
     return Objects.equals(this.errorCode, invoiceNotFoundException.errorCode) &&
         Objects.equals(this.message, invoiceNotFoundException.message) &&
-        Objects.equals(this.timestamp, invoiceNotFoundException.timestamp);
+        Objects.equals(this.timestamp, invoiceNotFoundException.timestamp)&&
+        Objects.equals(this.additionalProperties, invoiceNotFoundException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class InvoiceNotFoundException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class InvoiceNotFoundException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!InvoiceNotFoundException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InvoiceNotFoundException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InvoiceNotFoundException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class InvoiceNotFoundException {
            @Override
            public void write(JsonWriter out, InvoiceNotFoundException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class InvoiceNotFoundException {
            public InvoiceNotFoundException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             InvoiceNotFoundException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InvoicePaymentPlan.java
+++ b/java/src/main/java/com/kanmon/client/model/InvoicePaymentPlan.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -146,6 +146,50 @@ public class InvoicePaymentPlan {
     this.repaymentWindow = repaymentWindow;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the InvoicePaymentPlan instance itself
+   */
+  public InvoicePaymentPlan putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -160,12 +204,13 @@ public class InvoicePaymentPlan {
     return Objects.equals(this.id, invoicePaymentPlan.id) &&
         Objects.equals(this.advanceRatePercentage, invoicePaymentPlan.advanceRatePercentage) &&
         Objects.equals(this.transactionFeePercentage, invoicePaymentPlan.transactionFeePercentage) &&
-        Objects.equals(this.repaymentWindow, invoicePaymentPlan.repaymentWindow);
+        Objects.equals(this.repaymentWindow, invoicePaymentPlan.repaymentWindow)&&
+        Objects.equals(this.additionalProperties, invoicePaymentPlan.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, advanceRatePercentage, transactionFeePercentage, repaymentWindow);
+    return Objects.hash(id, advanceRatePercentage, transactionFeePercentage, repaymentWindow, additionalProperties);
   }
 
   @Override
@@ -176,6 +221,7 @@ public class InvoicePaymentPlan {
     sb.append("    advanceRatePercentage: ").append(toIndentedString(advanceRatePercentage)).append("\n");
     sb.append("    transactionFeePercentage: ").append(toIndentedString(transactionFeePercentage)).append("\n");
     sb.append("    repaymentWindow: ").append(toIndentedString(repaymentWindow)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -224,14 +270,6 @@ public class InvoicePaymentPlan {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!InvoicePaymentPlan.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InvoicePaymentPlan` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InvoicePaymentPlan.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -261,6 +299,28 @@ public class InvoicePaymentPlan {
            @Override
            public void write(JsonWriter out, InvoicePaymentPlan value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -268,7 +328,28 @@ public class InvoicePaymentPlan {
            public InvoicePaymentPlan read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             InvoicePaymentPlan instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InvoicePaymentPlanNotFoundException.java
+++ b/java/src/main/java/com/kanmon/client/model/InvoicePaymentPlanNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class InvoicePaymentPlanNotFoundException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the InvoicePaymentPlanNotFoundException instance itself
+   */
+  public InvoicePaymentPlanNotFoundException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class InvoicePaymentPlanNotFoundException {
     InvoicePaymentPlanNotFoundException invoicePaymentPlanNotFoundException = (InvoicePaymentPlanNotFoundException) o;
     return Objects.equals(this.errorCode, invoicePaymentPlanNotFoundException.errorCode) &&
         Objects.equals(this.message, invoicePaymentPlanNotFoundException.message) &&
-        Objects.equals(this.timestamp, invoicePaymentPlanNotFoundException.timestamp);
+        Objects.equals(this.timestamp, invoicePaymentPlanNotFoundException.timestamp)&&
+        Objects.equals(this.additionalProperties, invoicePaymentPlanNotFoundException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class InvoicePaymentPlanNotFoundException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class InvoicePaymentPlanNotFoundException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!InvoicePaymentPlanNotFoundException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InvoicePaymentPlanNotFoundException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InvoicePaymentPlanNotFoundException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class InvoicePaymentPlanNotFoundException {
            @Override
            public void write(JsonWriter out, InvoicePaymentPlanNotFoundException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class InvoicePaymentPlanNotFoundException {
            public InvoicePaymentPlanNotFoundException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             InvoicePaymentPlanNotFoundException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InvoicePaymentPlanRepaymentWindow.java
+++ b/java/src/main/java/com/kanmon/client/model/InvoicePaymentPlanRepaymentWindow.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/InvoiceRepaymentSchedule.java
+++ b/java/src/main/java/com/kanmon/client/model/InvoiceRepaymentSchedule.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -86,6 +86,50 @@ public class InvoiceRepaymentSchedule {
     this.schedule = schedule;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the InvoiceRepaymentSchedule instance itself
+   */
+  public InvoiceRepaymentSchedule putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -97,12 +141,13 @@ public class InvoiceRepaymentSchedule {
       return false;
     }
     InvoiceRepaymentSchedule invoiceRepaymentSchedule = (InvoiceRepaymentSchedule) o;
-    return Objects.equals(this.schedule, invoiceRepaymentSchedule.schedule);
+    return Objects.equals(this.schedule, invoiceRepaymentSchedule.schedule)&&
+        Objects.equals(this.additionalProperties, invoiceRepaymentSchedule.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(schedule);
+    return Objects.hash(schedule, additionalProperties);
   }
 
   @Override
@@ -110,6 +155,7 @@ public class InvoiceRepaymentSchedule {
     StringBuilder sb = new StringBuilder();
     sb.append("class InvoiceRepaymentSchedule {\n");
     sb.append("    schedule: ").append(toIndentedString(schedule)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -152,14 +198,6 @@ public class InvoiceRepaymentSchedule {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!InvoiceRepaymentSchedule.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InvoiceRepaymentSchedule` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InvoiceRepaymentSchedule.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -194,6 +232,28 @@ public class InvoiceRepaymentSchedule {
            @Override
            public void write(JsonWriter out, InvoiceRepaymentSchedule value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -201,7 +261,28 @@ public class InvoiceRepaymentSchedule {
            public InvoiceRepaymentSchedule read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             InvoiceRepaymentSchedule instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InvoiceRepaymentScheduleItem.java
+++ b/java/src/main/java/com/kanmon/client/model/InvoiceRepaymentScheduleItem.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -145,6 +145,50 @@ public class InvoiceRepaymentScheduleItem {
     this.repaymentPrincipalAmountCents = repaymentPrincipalAmountCents;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the InvoiceRepaymentScheduleItem instance itself
+   */
+  public InvoiceRepaymentScheduleItem putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -159,12 +203,13 @@ public class InvoiceRepaymentScheduleItem {
     return Objects.equals(this.repaymentDate, invoiceRepaymentScheduleItem.repaymentDate) &&
         Objects.equals(this.repaymentAmountCents, invoiceRepaymentScheduleItem.repaymentAmountCents) &&
         Objects.equals(this.repaymentFeeAmountCents, invoiceRepaymentScheduleItem.repaymentFeeAmountCents) &&
-        Objects.equals(this.repaymentPrincipalAmountCents, invoiceRepaymentScheduleItem.repaymentPrincipalAmountCents);
+        Objects.equals(this.repaymentPrincipalAmountCents, invoiceRepaymentScheduleItem.repaymentPrincipalAmountCents)&&
+        Objects.equals(this.additionalProperties, invoiceRepaymentScheduleItem.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(repaymentDate, repaymentAmountCents, repaymentFeeAmountCents, repaymentPrincipalAmountCents);
+    return Objects.hash(repaymentDate, repaymentAmountCents, repaymentFeeAmountCents, repaymentPrincipalAmountCents, additionalProperties);
   }
 
   @Override
@@ -175,6 +220,7 @@ public class InvoiceRepaymentScheduleItem {
     sb.append("    repaymentAmountCents: ").append(toIndentedString(repaymentAmountCents)).append("\n");
     sb.append("    repaymentFeeAmountCents: ").append(toIndentedString(repaymentFeeAmountCents)).append("\n");
     sb.append("    repaymentPrincipalAmountCents: ").append(toIndentedString(repaymentPrincipalAmountCents)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -223,14 +269,6 @@ public class InvoiceRepaymentScheduleItem {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!InvoiceRepaymentScheduleItem.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `InvoiceRepaymentScheduleItem` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : InvoiceRepaymentScheduleItem.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -258,6 +296,28 @@ public class InvoiceRepaymentScheduleItem {
            @Override
            public void write(JsonWriter out, InvoiceRepaymentScheduleItem value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -265,7 +325,28 @@ public class InvoiceRepaymentScheduleItem {
            public InvoiceRepaymentScheduleItem read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             InvoiceRepaymentScheduleItem instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/InvoiceStatus.java
+++ b/java/src/main/java/com/kanmon/client/model/InvoiceStatus.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/IssuedProduct.java
+++ b/java/src/main/java/com/kanmon/client/model/IssuedProduct.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -238,6 +238,50 @@ public class IssuedProduct {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IssuedProduct instance itself
+   */
+  public IssuedProduct putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -256,12 +300,13 @@ public class IssuedProduct {
         Objects.equals(this.loanStatus, issuedProduct.loanStatus) &&
         Objects.equals(this.servicingData, issuedProduct.servicingData) &&
         Objects.equals(this.createdAt, issuedProduct.createdAt) &&
-        Objects.equals(this.updatedAt, issuedProduct.updatedAt);
+        Objects.equals(this.updatedAt, issuedProduct.updatedAt)&&
+        Objects.equals(this.additionalProperties, issuedProduct.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, offerId, businessId, platformBusinessId, loanStatus, servicingData, createdAt, updatedAt);
+    return Objects.hash(id, offerId, businessId, platformBusinessId, loanStatus, servicingData, createdAt, updatedAt, additionalProperties);
   }
 
   @Override
@@ -276,6 +321,7 @@ public class IssuedProduct {
     sb.append("    servicingData: ").append(toIndentedString(servicingData)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -332,14 +378,6 @@ public class IssuedProduct {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IssuedProduct.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IssuedProduct` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IssuedProduct.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -386,6 +424,28 @@ public class IssuedProduct {
            @Override
            public void write(JsonWriter out, IssuedProduct value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -393,7 +453,28 @@ public class IssuedProduct {
            public IssuedProduct read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IssuedProduct instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/IssuedProductNotFoundException.java
+++ b/java/src/main/java/com/kanmon/client/model/IssuedProductNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class IssuedProductNotFoundException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IssuedProductNotFoundException instance itself
+   */
+  public IssuedProductNotFoundException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class IssuedProductNotFoundException {
     IssuedProductNotFoundException issuedProductNotFoundException = (IssuedProductNotFoundException) o;
     return Objects.equals(this.errorCode, issuedProductNotFoundException.errorCode) &&
         Objects.equals(this.message, issuedProductNotFoundException.message) &&
-        Objects.equals(this.timestamp, issuedProductNotFoundException.timestamp);
+        Objects.equals(this.timestamp, issuedProductNotFoundException.timestamp)&&
+        Objects.equals(this.additionalProperties, issuedProductNotFoundException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class IssuedProductNotFoundException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class IssuedProductNotFoundException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IssuedProductNotFoundException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IssuedProductNotFoundException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IssuedProductNotFoundException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class IssuedProductNotFoundException {
            @Override
            public void write(JsonWriter out, IssuedProductNotFoundException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class IssuedProductNotFoundException {
            public IssuedProductNotFoundException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IssuedProductNotFoundException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/IssuedProductServicingData.java
+++ b/java/src/main/java/com/kanmon/client/model/IssuedProductServicingData.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -26,6 +26,7 @@ import com.kanmon.client.model.InvoicePaymentPlan;
 import com.kanmon.client.model.LineOfCreditServicingData;
 import com.kanmon.client.model.McaServicingData;
 import com.kanmon.client.model.ProductType;
+import com.kanmon.client.model.RepaymentCadence;
 import com.kanmon.client.model.TermLoanServicingData;
 import java.io.IOException;
 import java.math.BigDecimal;

--- a/java/src/main/java/com/kanmon/client/model/IssuedProductStatusNotCurrentException.java
+++ b/java/src/main/java/com/kanmon/client/model/IssuedProductStatusNotCurrentException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class IssuedProductStatusNotCurrentException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the IssuedProductStatusNotCurrentException instance itself
+   */
+  public IssuedProductStatusNotCurrentException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class IssuedProductStatusNotCurrentException {
     IssuedProductStatusNotCurrentException issuedProductStatusNotCurrentException = (IssuedProductStatusNotCurrentException) o;
     return Objects.equals(this.errorCode, issuedProductStatusNotCurrentException.errorCode) &&
         Objects.equals(this.message, issuedProductStatusNotCurrentException.message) &&
-        Objects.equals(this.timestamp, issuedProductStatusNotCurrentException.timestamp);
+        Objects.equals(this.timestamp, issuedProductStatusNotCurrentException.timestamp)&&
+        Objects.equals(this.additionalProperties, issuedProductStatusNotCurrentException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class IssuedProductStatusNotCurrentException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class IssuedProductStatusNotCurrentException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!IssuedProductStatusNotCurrentException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `IssuedProductStatusNotCurrentException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : IssuedProductStatusNotCurrentException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class IssuedProductStatusNotCurrentException {
            @Override
            public void write(JsonWriter out, IssuedProductStatusNotCurrentException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class IssuedProductStatusNotCurrentException {
            public IssuedProductStatusNotCurrentException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             IssuedProductStatusNotCurrentException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/LineOfCreditOfferTerms.java
+++ b/java/src/main/java/com/kanmon/client/model/LineOfCreditOfferTerms.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -20,6 +20,7 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.kanmon.client.model.ProductType;
+import com.kanmon.client.model.RepaymentCadence;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -69,8 +70,21 @@ public class LineOfCreditOfferTerms {
   private BigDecimal feePercentage;
 
   public static final String SERIALIZED_NAME_REPAYMENT_DURATION_MONTHS = "repaymentDurationMonths";
+  @Deprecated
   @SerializedName(SERIALIZED_NAME_REPAYMENT_DURATION_MONTHS)
   private BigDecimal repaymentDurationMonths;
+
+  public static final String SERIALIZED_NAME_REPAYMENT_CADENCE = "repaymentCadence";
+  @SerializedName(SERIALIZED_NAME_REPAYMENT_CADENCE)
+  private RepaymentCadence repaymentCadence;
+
+  public static final String SERIALIZED_NAME_GRACE_PERIOD_DAYS = "gracePeriodDays";
+  @SerializedName(SERIALIZED_NAME_GRACE_PERIOD_DAYS)
+  private BigDecimal gracePeriodDays;
+
+  public static final String SERIALIZED_NAME_NUM_PAYMENT_PERIODS = "numPaymentPeriods";
+  @SerializedName(SERIALIZED_NAME_NUM_PAYMENT_PERIODS)
+  private BigDecimal numPaymentPeriods;
 
   public LineOfCreditOfferTerms() {
   }
@@ -151,24 +165,129 @@ public class LineOfCreditOfferTerms {
   }
 
 
+  @Deprecated
   public LineOfCreditOfferTerms repaymentDurationMonths(BigDecimal repaymentDurationMonths) {
     this.repaymentDurationMonths = repaymentDurationMonths;
     return this;
   }
 
   /**
-   * The duration of the repayment for each draw - in months.
+   * The duration of the repayment for each draw - in months. Deprecated: use &#x60;numPaymentPeriods&#x60; and &#x60;repaymentCadence&#x60; instead.
    * @return repaymentDurationMonths
+   * @deprecated
    */
+  @Deprecated
   @javax.annotation.Nonnull
   public BigDecimal getRepaymentDurationMonths() {
     return repaymentDurationMonths;
   }
 
+  @Deprecated
   public void setRepaymentDurationMonths(BigDecimal repaymentDurationMonths) {
     this.repaymentDurationMonths = repaymentDurationMonths;
   }
 
+
+  public LineOfCreditOfferTerms repaymentCadence(RepaymentCadence repaymentCadence) {
+    this.repaymentCadence = repaymentCadence;
+    return this;
+  }
+
+  /**
+   * Get repaymentCadence
+   * @return repaymentCadence
+   */
+  @javax.annotation.Nonnull
+  public RepaymentCadence getRepaymentCadence() {
+    return repaymentCadence;
+  }
+
+  public void setRepaymentCadence(RepaymentCadence repaymentCadence) {
+    this.repaymentCadence = repaymentCadence;
+  }
+
+
+  public LineOfCreditOfferTerms gracePeriodDays(BigDecimal gracePeriodDays) {
+    this.gracePeriodDays = gracePeriodDays;
+    return this;
+  }
+
+  /**
+   * The number of days after each draw during which no installment payments are due. Interest still accrues.
+   * @return gracePeriodDays
+   */
+  @javax.annotation.Nonnull
+  public BigDecimal getGracePeriodDays() {
+    return gracePeriodDays;
+  }
+
+  public void setGracePeriodDays(BigDecimal gracePeriodDays) {
+    this.gracePeriodDays = gracePeriodDays;
+  }
+
+
+  public LineOfCreditOfferTerms numPaymentPeriods(BigDecimal numPaymentPeriods) {
+    this.numPaymentPeriods = numPaymentPeriods;
+    return this;
+  }
+
+  /**
+   * The number of installment payment periods for each draw.
+   * @return numPaymentPeriods
+   */
+  @javax.annotation.Nonnull
+  public BigDecimal getNumPaymentPeriods() {
+    return numPaymentPeriods;
+  }
+
+  public void setNumPaymentPeriods(BigDecimal numPaymentPeriods) {
+    this.numPaymentPeriods = numPaymentPeriods;
+  }
+
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the LineOfCreditOfferTerms instance itself
+   */
+  public LineOfCreditOfferTerms putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +303,16 @@ public class LineOfCreditOfferTerms {
         Objects.equals(this.totalLimitCents, lineOfCreditOfferTerms.totalLimitCents) &&
         Objects.equals(this.interestRatePercentage, lineOfCreditOfferTerms.interestRatePercentage) &&
         Objects.equals(this.feePercentage, lineOfCreditOfferTerms.feePercentage) &&
-        Objects.equals(this.repaymentDurationMonths, lineOfCreditOfferTerms.repaymentDurationMonths);
+        Objects.equals(this.repaymentDurationMonths, lineOfCreditOfferTerms.repaymentDurationMonths) &&
+        Objects.equals(this.repaymentCadence, lineOfCreditOfferTerms.repaymentCadence) &&
+        Objects.equals(this.gracePeriodDays, lineOfCreditOfferTerms.gracePeriodDays) &&
+        Objects.equals(this.numPaymentPeriods, lineOfCreditOfferTerms.numPaymentPeriods)&&
+        Objects.equals(this.additionalProperties, lineOfCreditOfferTerms.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productType, totalLimitCents, interestRatePercentage, feePercentage, repaymentDurationMonths);
+    return Objects.hash(productType, totalLimitCents, interestRatePercentage, feePercentage, repaymentDurationMonths, repaymentCadence, gracePeriodDays, numPaymentPeriods, additionalProperties);
   }
 
   @Override
@@ -201,6 +324,10 @@ public class LineOfCreditOfferTerms {
     sb.append("    interestRatePercentage: ").append(toIndentedString(interestRatePercentage)).append("\n");
     sb.append("    feePercentage: ").append(toIndentedString(feePercentage)).append("\n");
     sb.append("    repaymentDurationMonths: ").append(toIndentedString(repaymentDurationMonths)).append("\n");
+    sb.append("    repaymentCadence: ").append(toIndentedString(repaymentCadence)).append("\n");
+    sb.append("    gracePeriodDays: ").append(toIndentedString(gracePeriodDays)).append("\n");
+    sb.append("    numPaymentPeriods: ").append(toIndentedString(numPaymentPeriods)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -228,6 +355,9 @@ public class LineOfCreditOfferTerms {
     openapiFields.add("interestRatePercentage");
     openapiFields.add("feePercentage");
     openapiFields.add("repaymentDurationMonths");
+    openapiFields.add("repaymentCadence");
+    openapiFields.add("gracePeriodDays");
+    openapiFields.add("numPaymentPeriods");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();
@@ -236,6 +366,9 @@ public class LineOfCreditOfferTerms {
     openapiRequiredFields.add("interestRatePercentage");
     openapiRequiredFields.add("feePercentage");
     openapiRequiredFields.add("repaymentDurationMonths");
+    openapiRequiredFields.add("repaymentCadence");
+    openapiRequiredFields.add("gracePeriodDays");
+    openapiRequiredFields.add("numPaymentPeriods");
   }
 
   /**
@@ -251,14 +384,6 @@ public class LineOfCreditOfferTerms {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!LineOfCreditOfferTerms.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `LineOfCreditOfferTerms` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : LineOfCreditOfferTerms.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -268,6 +393,8 @@ public class LineOfCreditOfferTerms {
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       // validate the required field `productType`
       ProductType.validateJsonElement(jsonObj.get("productType"));
+      // validate the required field `repaymentCadence`
+      RepaymentCadence.validateJsonElement(jsonObj.get("repaymentCadence"));
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
@@ -285,6 +412,28 @@ public class LineOfCreditOfferTerms {
            @Override
            public void write(JsonWriter out, LineOfCreditOfferTerms value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -292,7 +441,28 @@ public class LineOfCreditOfferTerms {
            public LineOfCreditOfferTerms read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             LineOfCreditOfferTerms instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/LineOfCreditServicingData.java
+++ b/java/src/main/java/com/kanmon/client/model/LineOfCreditServicingData.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -20,6 +20,7 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.kanmon.client.model.ProductType;
+import com.kanmon.client.model.RepaymentCadence;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -73,8 +74,21 @@ public class LineOfCreditServicingData {
   private BigDecimal feePercentage;
 
   public static final String SERIALIZED_NAME_REPAYMENT_DURATION_MONTHS = "repaymentDurationMonths";
+  @Deprecated
   @SerializedName(SERIALIZED_NAME_REPAYMENT_DURATION_MONTHS)
   private BigDecimal repaymentDurationMonths;
+
+  public static final String SERIALIZED_NAME_REPAYMENT_CADENCE = "repaymentCadence";
+  @SerializedName(SERIALIZED_NAME_REPAYMENT_CADENCE)
+  private RepaymentCadence repaymentCadence;
+
+  public static final String SERIALIZED_NAME_GRACE_PERIOD_DAYS = "gracePeriodDays";
+  @SerializedName(SERIALIZED_NAME_GRACE_PERIOD_DAYS)
+  private BigDecimal gracePeriodDays;
+
+  public static final String SERIALIZED_NAME_NUM_PAYMENT_PERIODS = "numPaymentPeriods";
+  @SerializedName(SERIALIZED_NAME_NUM_PAYMENT_PERIODS)
+  private BigDecimal numPaymentPeriods;
 
   public LineOfCreditServicingData() {
   }
@@ -174,24 +188,129 @@ public class LineOfCreditServicingData {
   }
 
 
+  @Deprecated
   public LineOfCreditServicingData repaymentDurationMonths(BigDecimal repaymentDurationMonths) {
     this.repaymentDurationMonths = repaymentDurationMonths;
     return this;
   }
 
   /**
-   * The duration of the repayment for each draw - in months.
+   * The duration of the repayment for each draw - in months. Deprecated: use &#x60;numPaymentPeriods&#x60; and &#x60;repaymentCadence&#x60; instead.
    * @return repaymentDurationMonths
+   * @deprecated
    */
+  @Deprecated
   @javax.annotation.Nonnull
   public BigDecimal getRepaymentDurationMonths() {
     return repaymentDurationMonths;
   }
 
+  @Deprecated
   public void setRepaymentDurationMonths(BigDecimal repaymentDurationMonths) {
     this.repaymentDurationMonths = repaymentDurationMonths;
   }
 
+
+  public LineOfCreditServicingData repaymentCadence(RepaymentCadence repaymentCadence) {
+    this.repaymentCadence = repaymentCadence;
+    return this;
+  }
+
+  /**
+   * Get repaymentCadence
+   * @return repaymentCadence
+   */
+  @javax.annotation.Nonnull
+  public RepaymentCadence getRepaymentCadence() {
+    return repaymentCadence;
+  }
+
+  public void setRepaymentCadence(RepaymentCadence repaymentCadence) {
+    this.repaymentCadence = repaymentCadence;
+  }
+
+
+  public LineOfCreditServicingData gracePeriodDays(BigDecimal gracePeriodDays) {
+    this.gracePeriodDays = gracePeriodDays;
+    return this;
+  }
+
+  /**
+   * The number of days after each draw during which no installment payments are due. Interest still accrues.
+   * @return gracePeriodDays
+   */
+  @javax.annotation.Nonnull
+  public BigDecimal getGracePeriodDays() {
+    return gracePeriodDays;
+  }
+
+  public void setGracePeriodDays(BigDecimal gracePeriodDays) {
+    this.gracePeriodDays = gracePeriodDays;
+  }
+
+
+  public LineOfCreditServicingData numPaymentPeriods(BigDecimal numPaymentPeriods) {
+    this.numPaymentPeriods = numPaymentPeriods;
+    return this;
+  }
+
+  /**
+   * The number of installment payment periods for each draw.
+   * @return numPaymentPeriods
+   */
+  @javax.annotation.Nonnull
+  public BigDecimal getNumPaymentPeriods() {
+    return numPaymentPeriods;
+  }
+
+  public void setNumPaymentPeriods(BigDecimal numPaymentPeriods) {
+    this.numPaymentPeriods = numPaymentPeriods;
+  }
+
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the LineOfCreditServicingData instance itself
+   */
+  public LineOfCreditServicingData putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -208,12 +327,16 @@ public class LineOfCreditServicingData {
         Objects.equals(this.availableLimitCents, lineOfCreditServicingData.availableLimitCents) &&
         Objects.equals(this.interestRatePercentage, lineOfCreditServicingData.interestRatePercentage) &&
         Objects.equals(this.feePercentage, lineOfCreditServicingData.feePercentage) &&
-        Objects.equals(this.repaymentDurationMonths, lineOfCreditServicingData.repaymentDurationMonths);
+        Objects.equals(this.repaymentDurationMonths, lineOfCreditServicingData.repaymentDurationMonths) &&
+        Objects.equals(this.repaymentCadence, lineOfCreditServicingData.repaymentCadence) &&
+        Objects.equals(this.gracePeriodDays, lineOfCreditServicingData.gracePeriodDays) &&
+        Objects.equals(this.numPaymentPeriods, lineOfCreditServicingData.numPaymentPeriods)&&
+        Objects.equals(this.additionalProperties, lineOfCreditServicingData.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productType, totalLimitCents, availableLimitCents, interestRatePercentage, feePercentage, repaymentDurationMonths);
+    return Objects.hash(productType, totalLimitCents, availableLimitCents, interestRatePercentage, feePercentage, repaymentDurationMonths, repaymentCadence, gracePeriodDays, numPaymentPeriods, additionalProperties);
   }
 
   @Override
@@ -226,6 +349,10 @@ public class LineOfCreditServicingData {
     sb.append("    interestRatePercentage: ").append(toIndentedString(interestRatePercentage)).append("\n");
     sb.append("    feePercentage: ").append(toIndentedString(feePercentage)).append("\n");
     sb.append("    repaymentDurationMonths: ").append(toIndentedString(repaymentDurationMonths)).append("\n");
+    sb.append("    repaymentCadence: ").append(toIndentedString(repaymentCadence)).append("\n");
+    sb.append("    gracePeriodDays: ").append(toIndentedString(gracePeriodDays)).append("\n");
+    sb.append("    numPaymentPeriods: ").append(toIndentedString(numPaymentPeriods)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -254,6 +381,9 @@ public class LineOfCreditServicingData {
     openapiFields.add("interestRatePercentage");
     openapiFields.add("feePercentage");
     openapiFields.add("repaymentDurationMonths");
+    openapiFields.add("repaymentCadence");
+    openapiFields.add("gracePeriodDays");
+    openapiFields.add("numPaymentPeriods");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();
@@ -263,6 +393,9 @@ public class LineOfCreditServicingData {
     openapiRequiredFields.add("interestRatePercentage");
     openapiRequiredFields.add("feePercentage");
     openapiRequiredFields.add("repaymentDurationMonths");
+    openapiRequiredFields.add("repaymentCadence");
+    openapiRequiredFields.add("gracePeriodDays");
+    openapiRequiredFields.add("numPaymentPeriods");
   }
 
   /**
@@ -278,14 +411,6 @@ public class LineOfCreditServicingData {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!LineOfCreditServicingData.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `LineOfCreditServicingData` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : LineOfCreditServicingData.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -295,6 +420,8 @@ public class LineOfCreditServicingData {
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       // validate the required field `productType`
       ProductType.validateJsonElement(jsonObj.get("productType"));
+      // validate the required field `repaymentCadence`
+      RepaymentCadence.validateJsonElement(jsonObj.get("repaymentCadence"));
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
@@ -312,6 +439,28 @@ public class LineOfCreditServicingData {
            @Override
            public void write(JsonWriter out, LineOfCreditServicingData value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -319,7 +468,28 @@ public class LineOfCreditServicingData {
            public LineOfCreditServicingData read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             LineOfCreditServicingData instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/LoanStatus.java
+++ b/java/src/main/java/com/kanmon/client/model/LoanStatus.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/McaOfferTerms.java
+++ b/java/src/main/java/com/kanmon/client/model/McaOfferTerms.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -294,6 +294,50 @@ public class McaOfferTerms {
     this.feeAmountCents = feeAmountCents;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the McaOfferTerms instance itself
+   */
+  public McaOfferTerms putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -312,12 +356,13 @@ public class McaOfferTerms {
         Objects.equals(this.repaymentFrequency, mcaOfferTerms.repaymentFrequency) &&
         Objects.equals(this.totalRepaymentCents, mcaOfferTerms.totalRepaymentCents) &&
         Objects.equals(this.maxAdvanceAmountCents, mcaOfferTerms.maxAdvanceAmountCents) &&
-        Objects.equals(this.feeAmountCents, mcaOfferTerms.feeAmountCents);
+        Objects.equals(this.feeAmountCents, mcaOfferTerms.feeAmountCents)&&
+        Objects.equals(this.additionalProperties, mcaOfferTerms.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productType, advanceAmountCents, repaymentPercentage, feeFactor, repaymentFrequency, totalRepaymentCents, maxAdvanceAmountCents, feeAmountCents);
+    return Objects.hash(productType, advanceAmountCents, repaymentPercentage, feeFactor, repaymentFrequency, totalRepaymentCents, maxAdvanceAmountCents, feeAmountCents, additionalProperties);
   }
 
   @Override
@@ -332,6 +377,7 @@ public class McaOfferTerms {
     sb.append("    totalRepaymentCents: ").append(toIndentedString(totalRepaymentCents)).append("\n");
     sb.append("    maxAdvanceAmountCents: ").append(toIndentedString(maxAdvanceAmountCents)).append("\n");
     sb.append("    feeAmountCents: ").append(toIndentedString(feeAmountCents)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -388,14 +434,6 @@ public class McaOfferTerms {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!McaOfferTerms.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `McaOfferTerms` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : McaOfferTerms.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -427,6 +465,28 @@ public class McaOfferTerms {
            @Override
            public void write(JsonWriter out, McaOfferTerms value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -434,7 +494,28 @@ public class McaOfferTerms {
            public McaOfferTerms read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             McaOfferTerms instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/McaServicingData.java
+++ b/java/src/main/java/com/kanmon/client/model/McaServicingData.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -317,6 +317,50 @@ public class McaServicingData {
     this.feeAmountCents = feeAmountCents;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the McaServicingData instance itself
+   */
+  public McaServicingData putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -336,12 +380,13 @@ public class McaServicingData {
         Objects.equals(this.repaymentFrequency, mcaServicingData.repaymentFrequency) &&
         Objects.equals(this.nextPaymentDate, mcaServicingData.nextPaymentDate) &&
         Objects.equals(this.advanceBalanceCents, mcaServicingData.advanceBalanceCents) &&
-        Objects.equals(this.feeAmountCents, mcaServicingData.feeAmountCents);
+        Objects.equals(this.feeAmountCents, mcaServicingData.feeAmountCents)&&
+        Objects.equals(this.additionalProperties, mcaServicingData.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productType, advanceAmountCents, repaymentPercentage, feeFactor, totalRepaymentCents, repaymentFrequency, nextPaymentDate, advanceBalanceCents, feeAmountCents);
+    return Objects.hash(productType, advanceAmountCents, repaymentPercentage, feeFactor, totalRepaymentCents, repaymentFrequency, nextPaymentDate, advanceBalanceCents, feeAmountCents, additionalProperties);
   }
 
   @Override
@@ -357,6 +402,7 @@ public class McaServicingData {
     sb.append("    nextPaymentDate: ").append(toIndentedString(nextPaymentDate)).append("\n");
     sb.append("    advanceBalanceCents: ").append(toIndentedString(advanceBalanceCents)).append("\n");
     sb.append("    feeAmountCents: ").append(toIndentedString(feeAmountCents)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -415,14 +461,6 @@ public class McaServicingData {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!McaServicingData.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `McaServicingData` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : McaServicingData.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -457,6 +495,28 @@ public class McaServicingData {
            @Override
            public void write(JsonWriter out, McaServicingData value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -464,7 +524,28 @@ public class McaServicingData {
            public McaServicingData read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             McaServicingData instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/MergeUsersRequestBody.java
+++ b/java/src/main/java/com/kanmon/client/model/MergeUsersRequestBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -144,6 +144,50 @@ public class MergeUsersRequestBody {
     this.targetBusinessId = targetBusinessId;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the MergeUsersRequestBody instance itself
+   */
+  public MergeUsersRequestBody putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -158,12 +202,13 @@ public class MergeUsersRequestBody {
     return Objects.equals(this.sourcePlatformBusinessId, mergeUsersRequestBody.sourcePlatformBusinessId) &&
         Objects.equals(this.sourceBusinessId, mergeUsersRequestBody.sourceBusinessId) &&
         Objects.equals(this.targetPlatformBusinessId, mergeUsersRequestBody.targetPlatformBusinessId) &&
-        Objects.equals(this.targetBusinessId, mergeUsersRequestBody.targetBusinessId);
+        Objects.equals(this.targetBusinessId, mergeUsersRequestBody.targetBusinessId)&&
+        Objects.equals(this.additionalProperties, mergeUsersRequestBody.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(sourcePlatformBusinessId, sourceBusinessId, targetPlatformBusinessId, targetBusinessId);
+    return Objects.hash(sourcePlatformBusinessId, sourceBusinessId, targetPlatformBusinessId, targetBusinessId, additionalProperties);
   }
 
   @Override
@@ -174,6 +219,7 @@ public class MergeUsersRequestBody {
     sb.append("    sourceBusinessId: ").append(toIndentedString(sourceBusinessId)).append("\n");
     sb.append("    targetPlatformBusinessId: ").append(toIndentedString(targetPlatformBusinessId)).append("\n");
     sb.append("    targetBusinessId: ").append(toIndentedString(targetBusinessId)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -217,14 +263,6 @@ public class MergeUsersRequestBody {
           throw new IllegalArgumentException(String.format("The required field(s) %s in MergeUsersRequestBody is not found in the empty JSON string", MergeUsersRequestBody.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!MergeUsersRequestBody.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MergeUsersRequestBody` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("sourcePlatformBusinessId") != null && !jsonObj.get("sourcePlatformBusinessId").isJsonNull()) && !jsonObj.get("sourcePlatformBusinessId").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `sourcePlatformBusinessId` to be a primitive type in the JSON string but got `%s`", jsonObj.get("sourcePlatformBusinessId").toString()));
@@ -255,6 +293,28 @@ public class MergeUsersRequestBody {
            @Override
            public void write(JsonWriter out, MergeUsersRequestBody value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -262,7 +322,28 @@ public class MergeUsersRequestBody {
            public MergeUsersRequestBody read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             MergeUsersRequestBody instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/MergeUsersResponseBody.java
+++ b/java/src/main/java/com/kanmon/client/model/MergeUsersResponseBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -86,6 +86,50 @@ public class MergeUsersResponseBody {
     this.mergedUsers = mergedUsers;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the MergeUsersResponseBody instance itself
+   */
+  public MergeUsersResponseBody putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -97,12 +141,13 @@ public class MergeUsersResponseBody {
       return false;
     }
     MergeUsersResponseBody mergeUsersResponseBody = (MergeUsersResponseBody) o;
-    return Objects.equals(this.mergedUsers, mergeUsersResponseBody.mergedUsers);
+    return Objects.equals(this.mergedUsers, mergeUsersResponseBody.mergedUsers)&&
+        Objects.equals(this.additionalProperties, mergeUsersResponseBody.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(mergedUsers);
+    return Objects.hash(mergedUsers, additionalProperties);
   }
 
   @Override
@@ -110,6 +155,7 @@ public class MergeUsersResponseBody {
     StringBuilder sb = new StringBuilder();
     sb.append("class MergeUsersResponseBody {\n");
     sb.append("    mergedUsers: ").append(toIndentedString(mergedUsers)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -152,14 +198,6 @@ public class MergeUsersResponseBody {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!MergeUsersResponseBody.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MergeUsersResponseBody` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : MergeUsersResponseBody.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -194,6 +232,28 @@ public class MergeUsersResponseBody {
            @Override
            public void write(JsonWriter out, MergeUsersResponseBody value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -201,7 +261,28 @@ public class MergeUsersResponseBody {
            public MergeUsersResponseBody read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             MergeUsersResponseBody instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/MultipleDurationInvoiceRepaymentWindow.java
+++ b/java/src/main/java/com/kanmon/client/model/MultipleDurationInvoiceRepaymentWindow.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -149,6 +149,50 @@ public class MultipleDurationInvoiceRepaymentWindow {
     this.repaymentSchedule = repaymentSchedule;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the MultipleDurationInvoiceRepaymentWindow instance itself
+   */
+  public MultipleDurationInvoiceRepaymentWindow putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -161,12 +205,13 @@ public class MultipleDurationInvoiceRepaymentWindow {
     }
     MultipleDurationInvoiceRepaymentWindow multipleDurationInvoiceRepaymentWindow = (MultipleDurationInvoiceRepaymentWindow) o;
     return Objects.equals(this.repaymentType, multipleDurationInvoiceRepaymentWindow.repaymentType) &&
-        Objects.equals(this.repaymentSchedule, multipleDurationInvoiceRepaymentWindow.repaymentSchedule);
+        Objects.equals(this.repaymentSchedule, multipleDurationInvoiceRepaymentWindow.repaymentSchedule)&&
+        Objects.equals(this.additionalProperties, multipleDurationInvoiceRepaymentWindow.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(repaymentType, repaymentSchedule);
+    return Objects.hash(repaymentType, repaymentSchedule, additionalProperties);
   }
 
   @Override
@@ -175,6 +220,7 @@ public class MultipleDurationInvoiceRepaymentWindow {
     sb.append("class MultipleDurationInvoiceRepaymentWindow {\n");
     sb.append("    repaymentType: ").append(toIndentedString(repaymentType)).append("\n");
     sb.append("    repaymentSchedule: ").append(toIndentedString(repaymentSchedule)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -219,14 +265,6 @@ public class MultipleDurationInvoiceRepaymentWindow {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!MultipleDurationInvoiceRepaymentWindow.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `MultipleDurationInvoiceRepaymentWindow` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : MultipleDurationInvoiceRepaymentWindow.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -258,6 +296,28 @@ public class MultipleDurationInvoiceRepaymentWindow {
            @Override
            public void write(JsonWriter out, MultipleDurationInvoiceRepaymentWindow value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -265,7 +325,28 @@ public class MultipleDurationInvoiceRepaymentWindow {
            public MultipleDurationInvoiceRepaymentWindow read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             MultipleDurationInvoiceRepaymentWindow instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/NoRemainingBalanceException.java
+++ b/java/src/main/java/com/kanmon/client/model/NoRemainingBalanceException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class NoRemainingBalanceException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the NoRemainingBalanceException instance itself
+   */
+  public NoRemainingBalanceException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class NoRemainingBalanceException {
     NoRemainingBalanceException noRemainingBalanceException = (NoRemainingBalanceException) o;
     return Objects.equals(this.errorCode, noRemainingBalanceException.errorCode) &&
         Objects.equals(this.message, noRemainingBalanceException.message) &&
-        Objects.equals(this.timestamp, noRemainingBalanceException.timestamp);
+        Objects.equals(this.timestamp, noRemainingBalanceException.timestamp)&&
+        Objects.equals(this.additionalProperties, noRemainingBalanceException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class NoRemainingBalanceException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class NoRemainingBalanceException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!NoRemainingBalanceException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `NoRemainingBalanceException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : NoRemainingBalanceException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class NoRemainingBalanceException {
            @Override
            public void write(JsonWriter out, NoRemainingBalanceException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class NoRemainingBalanceException {
            public NoRemainingBalanceException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             NoRemainingBalanceException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/Offer.java
+++ b/java/src/main/java/com/kanmon/client/model/Offer.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -237,6 +237,50 @@ public class Offer {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the Offer instance itself
+   */
+  public Offer putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -255,12 +299,13 @@ public class Offer {
         Objects.equals(this.expiredAt, offer.expiredAt) &&
         Objects.equals(this.selectedAt, offer.selectedAt) &&
         Objects.equals(this.createdAt, offer.createdAt) &&
-        Objects.equals(this.updatedAt, offer.updatedAt);
+        Objects.equals(this.updatedAt, offer.updatedAt)&&
+        Objects.equals(this.additionalProperties, offer.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, businessId, platformBusinessId, terms, expiredAt, selectedAt, createdAt, updatedAt);
+    return Objects.hash(id, businessId, platformBusinessId, terms, expiredAt, selectedAt, createdAt, updatedAt, additionalProperties);
   }
 
   @Override
@@ -275,6 +320,7 @@ public class Offer {
     sb.append("    selectedAt: ").append(toIndentedString(selectedAt)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -331,14 +377,6 @@ public class Offer {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!Offer.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `Offer` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : Offer.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -386,6 +424,28 @@ public class Offer {
            @Override
            public void write(JsonWriter out, Offer value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -393,7 +453,28 @@ public class Offer {
            public Offer read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             Offer instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/OfferAlreadySelectedException.java
+++ b/java/src/main/java/com/kanmon/client/model/OfferAlreadySelectedException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class OfferAlreadySelectedException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the OfferAlreadySelectedException instance itself
+   */
+  public OfferAlreadySelectedException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class OfferAlreadySelectedException {
     OfferAlreadySelectedException offerAlreadySelectedException = (OfferAlreadySelectedException) o;
     return Objects.equals(this.errorCode, offerAlreadySelectedException.errorCode) &&
         Objects.equals(this.message, offerAlreadySelectedException.message) &&
-        Objects.equals(this.timestamp, offerAlreadySelectedException.timestamp);
+        Objects.equals(this.timestamp, offerAlreadySelectedException.timestamp)&&
+        Objects.equals(this.additionalProperties, offerAlreadySelectedException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class OfferAlreadySelectedException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class OfferAlreadySelectedException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!OfferAlreadySelectedException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `OfferAlreadySelectedException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : OfferAlreadySelectedException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class OfferAlreadySelectedException {
            @Override
            public void write(JsonWriter out, OfferAlreadySelectedException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class OfferAlreadySelectedException {
            public OfferAlreadySelectedException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             OfferAlreadySelectedException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/OfferNotFoundException.java
+++ b/java/src/main/java/com/kanmon/client/model/OfferNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class OfferNotFoundException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the OfferNotFoundException instance itself
+   */
+  public OfferNotFoundException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class OfferNotFoundException {
     OfferNotFoundException offerNotFoundException = (OfferNotFoundException) o;
     return Objects.equals(this.errorCode, offerNotFoundException.errorCode) &&
         Objects.equals(this.message, offerNotFoundException.message) &&
-        Objects.equals(this.timestamp, offerNotFoundException.timestamp);
+        Objects.equals(this.timestamp, offerNotFoundException.timestamp)&&
+        Objects.equals(this.additionalProperties, offerNotFoundException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class OfferNotFoundException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class OfferNotFoundException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!OfferNotFoundException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `OfferNotFoundException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : OfferNotFoundException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class OfferNotFoundException {
            @Override
            public void write(JsonWriter out, OfferNotFoundException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class OfferNotFoundException {
            public OfferNotFoundException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             OfferNotFoundException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/OfferNotLockedException.java
+++ b/java/src/main/java/com/kanmon/client/model/OfferNotLockedException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class OfferNotLockedException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the OfferNotLockedException instance itself
+   */
+  public OfferNotLockedException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class OfferNotLockedException {
     OfferNotLockedException offerNotLockedException = (OfferNotLockedException) o;
     return Objects.equals(this.errorCode, offerNotLockedException.errorCode) &&
         Objects.equals(this.message, offerNotLockedException.message) &&
-        Objects.equals(this.timestamp, offerNotLockedException.timestamp);
+        Objects.equals(this.timestamp, offerNotLockedException.timestamp)&&
+        Objects.equals(this.additionalProperties, offerNotLockedException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class OfferNotLockedException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class OfferNotLockedException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!OfferNotLockedException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `OfferNotLockedException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : OfferNotLockedException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class OfferNotLockedException {
            @Override
            public void write(JsonWriter out, OfferNotLockedException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class OfferNotLockedException {
            public OfferNotLockedException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             OfferNotLockedException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/OfferTerms.java
+++ b/java/src/main/java/com/kanmon/client/model/OfferTerms.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -26,6 +26,7 @@ import com.kanmon.client.model.InvoicePaymentPlan;
 import com.kanmon.client.model.LineOfCreditOfferTerms;
 import com.kanmon.client.model.McaOfferTerms;
 import com.kanmon.client.model.ProductType;
+import com.kanmon.client.model.RepaymentCadence;
 import com.kanmon.client.model.TermLoanOfferTerms;
 import java.io.IOException;
 import java.math.BigDecimal;

--- a/java/src/main/java/com/kanmon/client/model/PaginationResult.java
+++ b/java/src/main/java/com/kanmon/client/model/PaginationResult.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -122,6 +122,50 @@ public class PaginationResult {
     this.totalCount = totalCount;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PaginationResult instance itself
+   */
+  public PaginationResult putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -135,12 +179,13 @@ public class PaginationResult {
     PaginationResult paginationResult = (PaginationResult) o;
     return Objects.equals(this.limit, paginationResult.limit) &&
         Objects.equals(this.offset, paginationResult.offset) &&
-        Objects.equals(this.totalCount, paginationResult.totalCount);
+        Objects.equals(this.totalCount, paginationResult.totalCount)&&
+        Objects.equals(this.additionalProperties, paginationResult.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(limit, offset, totalCount);
+    return Objects.hash(limit, offset, totalCount, additionalProperties);
   }
 
   @Override
@@ -150,6 +195,7 @@ public class PaginationResult {
     sb.append("    limit: ").append(toIndentedString(limit)).append("\n");
     sb.append("    offset: ").append(toIndentedString(offset)).append("\n");
     sb.append("    totalCount: ").append(toIndentedString(totalCount)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -196,14 +242,6 @@ public class PaginationResult {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PaginationResult.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PaginationResult` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PaginationResult.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -228,6 +266,28 @@ public class PaginationResult {
            @Override
            public void write(JsonWriter out, PaginationResult value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -235,7 +295,28 @@ public class PaginationResult {
            public PaginationResult read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PaginationResult instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/PaymentOrder.java
+++ b/java/src/main/java/com/kanmon/client/model/PaymentOrder.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -533,6 +533,50 @@ public class PaymentOrder {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PaymentOrder instance itself
+   */
+  public PaymentOrder putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -559,7 +603,8 @@ public class PaymentOrder {
         Objects.equals(this.direction, paymentOrder.direction) &&
         Objects.equals(this.status, paymentOrder.status) &&
         Objects.equals(this.createdAt, paymentOrder.createdAt) &&
-        Objects.equals(this.updatedAt, paymentOrder.updatedAt);
+        Objects.equals(this.updatedAt, paymentOrder.updatedAt)&&
+        Objects.equals(this.additionalProperties, paymentOrder.additionalProperties);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -568,7 +613,7 @@ public class PaymentOrder {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, issuedProductId, drawRequestId, invoiceId, platformInvoiceId, effectiveDate, settledDate, totalPaymentAmountCents, principalPaymentAmountCents, interestPaymentAmountCents, feePaymentAmountCents, feeType, direction, status, createdAt, updatedAt);
+    return Objects.hash(id, issuedProductId, drawRequestId, invoiceId, platformInvoiceId, effectiveDate, settledDate, totalPaymentAmountCents, principalPaymentAmountCents, interestPaymentAmountCents, feePaymentAmountCents, feeType, direction, status, createdAt, updatedAt, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -598,6 +643,7 @@ public class PaymentOrder {
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -669,14 +715,6 @@ public class PaymentOrder {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PaymentOrder.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PaymentOrder` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PaymentOrder.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -742,6 +780,28 @@ public class PaymentOrder {
            @Override
            public void write(JsonWriter out, PaymentOrder value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -749,7 +809,28 @@ public class PaymentOrder {
            public PaymentOrder read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PaymentOrder instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/PaymentOrderNotFoundException.java
+++ b/java/src/main/java/com/kanmon/client/model/PaymentOrderNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class PaymentOrderNotFoundException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PaymentOrderNotFoundException instance itself
+   */
+  public PaymentOrderNotFoundException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class PaymentOrderNotFoundException {
     PaymentOrderNotFoundException paymentOrderNotFoundException = (PaymentOrderNotFoundException) o;
     return Objects.equals(this.errorCode, paymentOrderNotFoundException.errorCode) &&
         Objects.equals(this.message, paymentOrderNotFoundException.message) &&
-        Objects.equals(this.timestamp, paymentOrderNotFoundException.timestamp);
+        Objects.equals(this.timestamp, paymentOrderNotFoundException.timestamp)&&
+        Objects.equals(this.additionalProperties, paymentOrderNotFoundException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class PaymentOrderNotFoundException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class PaymentOrderNotFoundException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PaymentOrderNotFoundException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PaymentOrderNotFoundException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PaymentOrderNotFoundException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class PaymentOrderNotFoundException {
            @Override
            public void write(JsonWriter out, PaymentOrderNotFoundException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class PaymentOrderNotFoundException {
            public PaymentOrderNotFoundException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PaymentOrderNotFoundException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/PaymentOrderStatus.java
+++ b/java/src/main/java/com/kanmon/client/model/PaymentOrderStatus.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/PaymentPlanRepaymentSchedule.java
+++ b/java/src/main/java/com/kanmon/client/model/PaymentPlanRepaymentSchedule.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -86,6 +86,50 @@ public class PaymentPlanRepaymentSchedule {
     this.schedule = schedule;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PaymentPlanRepaymentSchedule instance itself
+   */
+  public PaymentPlanRepaymentSchedule putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -97,12 +141,13 @@ public class PaymentPlanRepaymentSchedule {
       return false;
     }
     PaymentPlanRepaymentSchedule paymentPlanRepaymentSchedule = (PaymentPlanRepaymentSchedule) o;
-    return Objects.equals(this.schedule, paymentPlanRepaymentSchedule.schedule);
+    return Objects.equals(this.schedule, paymentPlanRepaymentSchedule.schedule)&&
+        Objects.equals(this.additionalProperties, paymentPlanRepaymentSchedule.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(schedule);
+    return Objects.hash(schedule, additionalProperties);
   }
 
   @Override
@@ -110,6 +155,7 @@ public class PaymentPlanRepaymentSchedule {
     StringBuilder sb = new StringBuilder();
     sb.append("class PaymentPlanRepaymentSchedule {\n");
     sb.append("    schedule: ").append(toIndentedString(schedule)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -152,14 +198,6 @@ public class PaymentPlanRepaymentSchedule {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PaymentPlanRepaymentSchedule.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PaymentPlanRepaymentSchedule` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PaymentPlanRepaymentSchedule.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -194,6 +232,28 @@ public class PaymentPlanRepaymentSchedule {
            @Override
            public void write(JsonWriter out, PaymentPlanRepaymentSchedule value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -201,7 +261,28 @@ public class PaymentPlanRepaymentSchedule {
            public PaymentPlanRepaymentSchedule read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PaymentPlanRepaymentSchedule instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/PaymentPlanRepaymentScheduleItem.java
+++ b/java/src/main/java/com/kanmon/client/model/PaymentPlanRepaymentScheduleItem.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -99,6 +99,50 @@ public class PaymentPlanRepaymentScheduleItem {
     this.repaymentPercentage = repaymentPercentage;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PaymentPlanRepaymentScheduleItem instance itself
+   */
+  public PaymentPlanRepaymentScheduleItem putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -111,12 +155,13 @@ public class PaymentPlanRepaymentScheduleItem {
     }
     PaymentPlanRepaymentScheduleItem paymentPlanRepaymentScheduleItem = (PaymentPlanRepaymentScheduleItem) o;
     return Objects.equals(this.repaymentDurationDays, paymentPlanRepaymentScheduleItem.repaymentDurationDays) &&
-        Objects.equals(this.repaymentPercentage, paymentPlanRepaymentScheduleItem.repaymentPercentage);
+        Objects.equals(this.repaymentPercentage, paymentPlanRepaymentScheduleItem.repaymentPercentage)&&
+        Objects.equals(this.additionalProperties, paymentPlanRepaymentScheduleItem.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(repaymentDurationDays, repaymentPercentage);
+    return Objects.hash(repaymentDurationDays, repaymentPercentage, additionalProperties);
   }
 
   @Override
@@ -125,6 +170,7 @@ public class PaymentPlanRepaymentScheduleItem {
     sb.append("class PaymentPlanRepaymentScheduleItem {\n");
     sb.append("    repaymentDurationDays: ").append(toIndentedString(repaymentDurationDays)).append("\n");
     sb.append("    repaymentPercentage: ").append(toIndentedString(repaymentPercentage)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -169,14 +215,6 @@ public class PaymentPlanRepaymentScheduleItem {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PaymentPlanRepaymentScheduleItem.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PaymentPlanRepaymentScheduleItem` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PaymentPlanRepaymentScheduleItem.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -201,6 +239,28 @@ public class PaymentPlanRepaymentScheduleItem {
            @Override
            public void write(JsonWriter out, PaymentPlanRepaymentScheduleItem value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -208,7 +268,28 @@ public class PaymentPlanRepaymentScheduleItem {
            public PaymentPlanRepaymentScheduleItem read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PaymentPlanRepaymentScheduleItem instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/PaymentScheduleItem.java
+++ b/java/src/main/java/com/kanmon/client/model/PaymentScheduleItem.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -124,6 +124,50 @@ public class PaymentScheduleItem {
     this.paymentOrder = paymentOrder;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PaymentScheduleItem instance itself
+   */
+  public PaymentScheduleItem putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -137,7 +181,8 @@ public class PaymentScheduleItem {
     PaymentScheduleItem paymentScheduleItem = (PaymentScheduleItem) o;
     return Objects.equals(this.effectiveDate, paymentScheduleItem.effectiveDate) &&
         Objects.equals(this.totalPaymentAmountCents, paymentScheduleItem.totalPaymentAmountCents) &&
-        Objects.equals(this.paymentOrder, paymentScheduleItem.paymentOrder);
+        Objects.equals(this.paymentOrder, paymentScheduleItem.paymentOrder)&&
+        Objects.equals(this.additionalProperties, paymentScheduleItem.additionalProperties);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -146,7 +191,7 @@ public class PaymentScheduleItem {
 
   @Override
   public int hashCode() {
-    return Objects.hash(effectiveDate, totalPaymentAmountCents, paymentOrder);
+    return Objects.hash(effectiveDate, totalPaymentAmountCents, paymentOrder, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -163,6 +208,7 @@ public class PaymentScheduleItem {
     sb.append("    effectiveDate: ").append(toIndentedString(effectiveDate)).append("\n");
     sb.append("    totalPaymentAmountCents: ").append(toIndentedString(totalPaymentAmountCents)).append("\n");
     sb.append("    paymentOrder: ").append(toIndentedString(paymentOrder)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -208,14 +254,6 @@ public class PaymentScheduleItem {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PaymentScheduleItem.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PaymentScheduleItem` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PaymentScheduleItem.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -247,6 +285,28 @@ public class PaymentScheduleItem {
            @Override
            public void write(JsonWriter out, PaymentScheduleItem value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -254,7 +314,28 @@ public class PaymentScheduleItem {
            public PaymentScheduleItem read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PaymentScheduleItem instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/PlaidAssetReportsInvalidException.java
+++ b/java/src/main/java/com/kanmon/client/model/PlaidAssetReportsInvalidException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class PlaidAssetReportsInvalidException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PlaidAssetReportsInvalidException instance itself
+   */
+  public PlaidAssetReportsInvalidException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class PlaidAssetReportsInvalidException {
     PlaidAssetReportsInvalidException plaidAssetReportsInvalidException = (PlaidAssetReportsInvalidException) o;
     return Objects.equals(this.errorCode, plaidAssetReportsInvalidException.errorCode) &&
         Objects.equals(this.message, plaidAssetReportsInvalidException.message) &&
-        Objects.equals(this.timestamp, plaidAssetReportsInvalidException.timestamp);
+        Objects.equals(this.timestamp, plaidAssetReportsInvalidException.timestamp)&&
+        Objects.equals(this.additionalProperties, plaidAssetReportsInvalidException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class PlaidAssetReportsInvalidException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class PlaidAssetReportsInvalidException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PlaidAssetReportsInvalidException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PlaidAssetReportsInvalidException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PlaidAssetReportsInvalidException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class PlaidAssetReportsInvalidException {
            @Override
            public void write(JsonWriter out, PlaidAssetReportsInvalidException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class PlaidAssetReportsInvalidException {
            public PlaidAssetReportsInvalidException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PlaidAssetReportsInvalidException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/PlatformInvoiceIdAlreadyExistsException.java
+++ b/java/src/main/java/com/kanmon/client/model/PlatformInvoiceIdAlreadyExistsException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class PlatformInvoiceIdAlreadyExistsException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PlatformInvoiceIdAlreadyExistsException instance itself
+   */
+  public PlatformInvoiceIdAlreadyExistsException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class PlatformInvoiceIdAlreadyExistsException {
     PlatformInvoiceIdAlreadyExistsException platformInvoiceIdAlreadyExistsException = (PlatformInvoiceIdAlreadyExistsException) o;
     return Objects.equals(this.errorCode, platformInvoiceIdAlreadyExistsException.errorCode) &&
         Objects.equals(this.message, platformInvoiceIdAlreadyExistsException.message) &&
-        Objects.equals(this.timestamp, platformInvoiceIdAlreadyExistsException.timestamp);
+        Objects.equals(this.timestamp, platformInvoiceIdAlreadyExistsException.timestamp)&&
+        Objects.equals(this.additionalProperties, platformInvoiceIdAlreadyExistsException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class PlatformInvoiceIdAlreadyExistsException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class PlatformInvoiceIdAlreadyExistsException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PlatformInvoiceIdAlreadyExistsException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PlatformInvoiceIdAlreadyExistsException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PlatformInvoiceIdAlreadyExistsException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class PlatformInvoiceIdAlreadyExistsException {
            @Override
            public void write(JsonWriter out, PlatformInvoiceIdAlreadyExistsException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class PlatformInvoiceIdAlreadyExistsException {
            public PlatformInvoiceIdAlreadyExistsException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PlatformInvoiceIdAlreadyExistsException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException.java
+++ b/java/src/main/java/com/kanmon/client/model/PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException instance itself
+   */
+  public PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException {
     PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException platformInvoiceIdAlreadyExistsForAnotherIssuedProductException = (PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException) o;
     return Objects.equals(this.errorCode, platformInvoiceIdAlreadyExistsForAnotherIssuedProductException.errorCode) &&
         Objects.equals(this.message, platformInvoiceIdAlreadyExistsForAnotherIssuedProductException.message) &&
-        Objects.equals(this.timestamp, platformInvoiceIdAlreadyExistsForAnotherIssuedProductException.timestamp);
+        Objects.equals(this.timestamp, platformInvoiceIdAlreadyExistsForAnotherIssuedProductException.timestamp)&&
+        Objects.equals(this.additionalProperties, platformInvoiceIdAlreadyExistsForAnotherIssuedProductException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException {
            @Override
            public void write(JsonWriter out, PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException {
            public PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/PlatformInvoiceNumberAlreadyExistsForIssuedProductException.java
+++ b/java/src/main/java/com/kanmon/client/model/PlatformInvoiceNumberAlreadyExistsForIssuedProductException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class PlatformInvoiceNumberAlreadyExistsForIssuedProductException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PlatformInvoiceNumberAlreadyExistsForIssuedProductException instance itself
+   */
+  public PlatformInvoiceNumberAlreadyExistsForIssuedProductException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class PlatformInvoiceNumberAlreadyExistsForIssuedProductException {
     PlatformInvoiceNumberAlreadyExistsForIssuedProductException platformInvoiceNumberAlreadyExistsForIssuedProductException = (PlatformInvoiceNumberAlreadyExistsForIssuedProductException) o;
     return Objects.equals(this.errorCode, platformInvoiceNumberAlreadyExistsForIssuedProductException.errorCode) &&
         Objects.equals(this.message, platformInvoiceNumberAlreadyExistsForIssuedProductException.message) &&
-        Objects.equals(this.timestamp, platformInvoiceNumberAlreadyExistsForIssuedProductException.timestamp);
+        Objects.equals(this.timestamp, platformInvoiceNumberAlreadyExistsForIssuedProductException.timestamp)&&
+        Objects.equals(this.additionalProperties, platformInvoiceNumberAlreadyExistsForIssuedProductException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class PlatformInvoiceNumberAlreadyExistsForIssuedProductException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class PlatformInvoiceNumberAlreadyExistsForIssuedProductException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PlatformInvoiceNumberAlreadyExistsForIssuedProductException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PlatformInvoiceNumberAlreadyExistsForIssuedProductException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PlatformInvoiceNumberAlreadyExistsForIssuedProductException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class PlatformInvoiceNumberAlreadyExistsForIssuedProductException {
            @Override
            public void write(JsonWriter out, PlatformInvoiceNumberAlreadyExistsForIssuedProductException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class PlatformInvoiceNumberAlreadyExistsForIssuedProductException {
            public PlatformInvoiceNumberAlreadyExistsForIssuedProductException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PlatformInvoiceNumberAlreadyExistsForIssuedProductException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/PrimaryBusinessOwnerAlreadyExistsForBusinessException.java
+++ b/java/src/main/java/com/kanmon/client/model/PrimaryBusinessOwnerAlreadyExistsForBusinessException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class PrimaryBusinessOwnerAlreadyExistsForBusinessException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PrimaryBusinessOwnerAlreadyExistsForBusinessException instance itself
+   */
+  public PrimaryBusinessOwnerAlreadyExistsForBusinessException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class PrimaryBusinessOwnerAlreadyExistsForBusinessException {
     PrimaryBusinessOwnerAlreadyExistsForBusinessException primaryBusinessOwnerAlreadyExistsForBusinessException = (PrimaryBusinessOwnerAlreadyExistsForBusinessException) o;
     return Objects.equals(this.errorCode, primaryBusinessOwnerAlreadyExistsForBusinessException.errorCode) &&
         Objects.equals(this.message, primaryBusinessOwnerAlreadyExistsForBusinessException.message) &&
-        Objects.equals(this.timestamp, primaryBusinessOwnerAlreadyExistsForBusinessException.timestamp);
+        Objects.equals(this.timestamp, primaryBusinessOwnerAlreadyExistsForBusinessException.timestamp)&&
+        Objects.equals(this.additionalProperties, primaryBusinessOwnerAlreadyExistsForBusinessException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class PrimaryBusinessOwnerAlreadyExistsForBusinessException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class PrimaryBusinessOwnerAlreadyExistsForBusinessException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PrimaryBusinessOwnerAlreadyExistsForBusinessException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PrimaryBusinessOwnerAlreadyExistsForBusinessException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PrimaryBusinessOwnerAlreadyExistsForBusinessException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class PrimaryBusinessOwnerAlreadyExistsForBusinessException {
            @Override
            public void write(JsonWriter out, PrimaryBusinessOwnerAlreadyExistsForBusinessException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class PrimaryBusinessOwnerAlreadyExistsForBusinessException {
            public PrimaryBusinessOwnerAlreadyExistsForBusinessException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PrimaryBusinessOwnerAlreadyExistsForBusinessException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/PrimaryBusinessOwnerAlreadyExistsWithEmailException.java
+++ b/java/src/main/java/com/kanmon/client/model/PrimaryBusinessOwnerAlreadyExistsWithEmailException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class PrimaryBusinessOwnerAlreadyExistsWithEmailException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PrimaryBusinessOwnerAlreadyExistsWithEmailException instance itself
+   */
+  public PrimaryBusinessOwnerAlreadyExistsWithEmailException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class PrimaryBusinessOwnerAlreadyExistsWithEmailException {
     PrimaryBusinessOwnerAlreadyExistsWithEmailException primaryBusinessOwnerAlreadyExistsWithEmailException = (PrimaryBusinessOwnerAlreadyExistsWithEmailException) o;
     return Objects.equals(this.errorCode, primaryBusinessOwnerAlreadyExistsWithEmailException.errorCode) &&
         Objects.equals(this.message, primaryBusinessOwnerAlreadyExistsWithEmailException.message) &&
-        Objects.equals(this.timestamp, primaryBusinessOwnerAlreadyExistsWithEmailException.timestamp);
+        Objects.equals(this.timestamp, primaryBusinessOwnerAlreadyExistsWithEmailException.timestamp)&&
+        Objects.equals(this.additionalProperties, primaryBusinessOwnerAlreadyExistsWithEmailException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class PrimaryBusinessOwnerAlreadyExistsWithEmailException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class PrimaryBusinessOwnerAlreadyExistsWithEmailException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PrimaryBusinessOwnerAlreadyExistsWithEmailException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PrimaryBusinessOwnerAlreadyExistsWithEmailException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PrimaryBusinessOwnerAlreadyExistsWithEmailException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class PrimaryBusinessOwnerAlreadyExistsWithEmailException {
            @Override
            public void write(JsonWriter out, PrimaryBusinessOwnerAlreadyExistsWithEmailException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class PrimaryBusinessOwnerAlreadyExistsWithEmailException {
            public PrimaryBusinessOwnerAlreadyExistsWithEmailException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PrimaryBusinessOwnerAlreadyExistsWithEmailException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/PrimaryBusinessOwnerNotFoundException.java
+++ b/java/src/main/java/com/kanmon/client/model/PrimaryBusinessOwnerNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class PrimaryBusinessOwnerNotFoundException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the PrimaryBusinessOwnerNotFoundException instance itself
+   */
+  public PrimaryBusinessOwnerNotFoundException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class PrimaryBusinessOwnerNotFoundException {
     PrimaryBusinessOwnerNotFoundException primaryBusinessOwnerNotFoundException = (PrimaryBusinessOwnerNotFoundException) o;
     return Objects.equals(this.errorCode, primaryBusinessOwnerNotFoundException.errorCode) &&
         Objects.equals(this.message, primaryBusinessOwnerNotFoundException.message) &&
-        Objects.equals(this.timestamp, primaryBusinessOwnerNotFoundException.timestamp);
+        Objects.equals(this.timestamp, primaryBusinessOwnerNotFoundException.timestamp)&&
+        Objects.equals(this.additionalProperties, primaryBusinessOwnerNotFoundException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class PrimaryBusinessOwnerNotFoundException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class PrimaryBusinessOwnerNotFoundException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!PrimaryBusinessOwnerNotFoundException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `PrimaryBusinessOwnerNotFoundException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : PrimaryBusinessOwnerNotFoundException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class PrimaryBusinessOwnerNotFoundException {
            @Override
            public void write(JsonWriter out, PrimaryBusinessOwnerNotFoundException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class PrimaryBusinessOwnerNotFoundException {
            public PrimaryBusinessOwnerNotFoundException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             PrimaryBusinessOwnerNotFoundException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/RepaymentCadence.java
+++ b/java/src/main/java/com/kanmon/client/model/RepaymentCadence.java
@@ -24,26 +24,18 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 /**
- * Gets or Sets ProductType
+ * Gets or Sets RepaymentCadence
  */
-@JsonAdapter(ProductType.Adapter.class)
-public enum ProductType {
+@JsonAdapter(RepaymentCadence.Adapter.class)
+public enum RepaymentCadence {
   
-  INVOICE_FINANCING("INVOICE_FINANCING"),
+  WEEKLY("WEEKLY"),
   
-  TERM_LOAN("TERM_LOAN"),
-  
-  MCA("MCA"),
-  
-  LINE_OF_CREDIT("LINE_OF_CREDIT"),
-  
-  INTEGRATED_MCA("INTEGRATED_MCA"),
-  
-  ACCOUNTS_PAYABLE_FINANCING("ACCOUNTS_PAYABLE_FINANCING");
+  MONTHLY("MONTHLY");
 
   private String value;
 
-  ProductType(String value) {
+  RepaymentCadence(String value) {
     this.value = value;
   }
 
@@ -56,8 +48,8 @@ public enum ProductType {
     return String.valueOf(value);
   }
 
-  public static ProductType fromValue(String value) {
-    for (ProductType b : ProductType.values()) {
+  public static RepaymentCadence fromValue(String value) {
+    for (RepaymentCadence b : RepaymentCadence.values()) {
       if (b.value.equals(value)) {
         return b;
       }
@@ -65,22 +57,22 @@ public enum ProductType {
     throw new IllegalArgumentException("Unexpected value '" + value + "'");
   }
 
-  public static class Adapter extends TypeAdapter<ProductType> {
+  public static class Adapter extends TypeAdapter<RepaymentCadence> {
     @Override
-    public void write(final JsonWriter jsonWriter, final ProductType enumeration) throws IOException {
+    public void write(final JsonWriter jsonWriter, final RepaymentCadence enumeration) throws IOException {
       jsonWriter.value(enumeration.getValue());
     }
 
     @Override
-    public ProductType read(final JsonReader jsonReader) throws IOException {
+    public RepaymentCadence read(final JsonReader jsonReader) throws IOException {
       String value = jsonReader.nextString();
-      return ProductType.fromValue(value);
+      return RepaymentCadence.fromValue(value);
     }
   }
 
   public static void validateJsonElement(JsonElement jsonElement) throws IOException {
     String value = jsonElement.getAsString();
-    ProductType.fromValue(value);
+    RepaymentCadence.fromValue(value);
   }
 }
 

--- a/java/src/main/java/com/kanmon/client/model/SessionInvoice.java
+++ b/java/src/main/java/com/kanmon/client/model/SessionInvoice.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -405,6 +405,50 @@ public class SessionInvoice {
     this.description = description;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the SessionInvoice instance itself
+   */
+  public SessionInvoice putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -428,12 +472,13 @@ public class SessionInvoice {
         Objects.equals(this.payorFirstName, sessionInvoice.payorFirstName) &&
         Objects.equals(this.payorMiddleName, sessionInvoice.payorMiddleName) &&
         Objects.equals(this.payorLastName, sessionInvoice.payorLastName) &&
-        Objects.equals(this.description, sessionInvoice.description);
+        Objects.equals(this.description, sessionInvoice.description)&&
+        Objects.equals(this.additionalProperties, sessionInvoice.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(platformInvoiceId, platformInvoiceNumber, invoiceAmountCents, invoiceDueDate, invoiceIssuedDate, payorEmail, payorAddress, payorType, payorBusinessName, payorFirstName, payorMiddleName, payorLastName, description);
+    return Objects.hash(platformInvoiceId, platformInvoiceNumber, invoiceAmountCents, invoiceDueDate, invoiceIssuedDate, payorEmail, payorAddress, payorType, payorBusinessName, payorFirstName, payorMiddleName, payorLastName, description, additionalProperties);
   }
 
   @Override
@@ -453,6 +498,7 @@ public class SessionInvoice {
     sb.append("    payorMiddleName: ").append(toIndentedString(payorMiddleName)).append("\n");
     sb.append("    payorLastName: ").append(toIndentedString(payorLastName)).append("\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -510,14 +556,6 @@ public class SessionInvoice {
       if (jsonElement == null) {
         if (!SessionInvoice.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
           throw new IllegalArgumentException(String.format("The required field(s) %s in SessionInvoice is not found in the empty JSON string", SessionInvoice.openapiRequiredFields.toString()));
-        }
-      }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!SessionInvoice.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SessionInvoice` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
         }
       }
 
@@ -584,6 +622,28 @@ public class SessionInvoice {
            @Override
            public void write(JsonWriter out, SessionInvoice value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -591,7 +651,28 @@ public class SessionInvoice {
            public SessionInvoice read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             SessionInvoice instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/SessionInvoiceWithInvoiceFile.java
+++ b/java/src/main/java/com/kanmon/client/model/SessionInvoiceWithInvoiceFile.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -428,6 +428,50 @@ public class SessionInvoiceWithInvoiceFile {
     this.description = description;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the SessionInvoiceWithInvoiceFile instance itself
+   */
+  public SessionInvoiceWithInvoiceFile putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -452,12 +496,13 @@ public class SessionInvoiceWithInvoiceFile {
         Objects.equals(this.payorFirstName, sessionInvoiceWithInvoiceFile.payorFirstName) &&
         Objects.equals(this.payorMiddleName, sessionInvoiceWithInvoiceFile.payorMiddleName) &&
         Objects.equals(this.payorLastName, sessionInvoiceWithInvoiceFile.payorLastName) &&
-        Objects.equals(this.description, sessionInvoiceWithInvoiceFile.description);
+        Objects.equals(this.description, sessionInvoiceWithInvoiceFile.description)&&
+        Objects.equals(this.additionalProperties, sessionInvoiceWithInvoiceFile.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(platformInvoiceId, documentId, platformInvoiceNumber, invoiceAmountCents, invoiceDueDate, invoiceIssuedDate, payorEmail, payorAddress, payorType, payorBusinessName, payorFirstName, payorMiddleName, payorLastName, description);
+    return Objects.hash(platformInvoiceId, documentId, platformInvoiceNumber, invoiceAmountCents, invoiceDueDate, invoiceIssuedDate, payorEmail, payorAddress, payorType, payorBusinessName, payorFirstName, payorMiddleName, payorLastName, description, additionalProperties);
   }
 
   @Override
@@ -478,6 +523,7 @@ public class SessionInvoiceWithInvoiceFile {
     sb.append("    payorMiddleName: ").append(toIndentedString(payorMiddleName)).append("\n");
     sb.append("    payorLastName: ").append(toIndentedString(payorLastName)).append("\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -531,14 +577,6 @@ public class SessionInvoiceWithInvoiceFile {
       if (jsonElement == null) {
         if (!SessionInvoiceWithInvoiceFile.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
           throw new IllegalArgumentException(String.format("The required field(s) %s in SessionInvoiceWithInvoiceFile is not found in the empty JSON string", SessionInvoiceWithInvoiceFile.openapiRequiredFields.toString()));
-        }
-      }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!SessionInvoiceWithInvoiceFile.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SessionInvoiceWithInvoiceFile` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
         }
       }
 
@@ -610,6 +648,28 @@ public class SessionInvoiceWithInvoiceFile {
            @Override
            public void write(JsonWriter out, SessionInvoiceWithInvoiceFile value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -617,7 +677,28 @@ public class SessionInvoiceWithInvoiceFile {
            public SessionInvoiceWithInvoiceFile read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             SessionInvoiceWithInvoiceFile instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/SomeOffersHaveExpiredException.java
+++ b/java/src/main/java/com/kanmon/client/model/SomeOffersHaveExpiredException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class SomeOffersHaveExpiredException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the SomeOffersHaveExpiredException instance itself
+   */
+  public SomeOffersHaveExpiredException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class SomeOffersHaveExpiredException {
     SomeOffersHaveExpiredException someOffersHaveExpiredException = (SomeOffersHaveExpiredException) o;
     return Objects.equals(this.errorCode, someOffersHaveExpiredException.errorCode) &&
         Objects.equals(this.message, someOffersHaveExpiredException.message) &&
-        Objects.equals(this.timestamp, someOffersHaveExpiredException.timestamp);
+        Objects.equals(this.timestamp, someOffersHaveExpiredException.timestamp)&&
+        Objects.equals(this.additionalProperties, someOffersHaveExpiredException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class SomeOffersHaveExpiredException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class SomeOffersHaveExpiredException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!SomeOffersHaveExpiredException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `SomeOffersHaveExpiredException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : SomeOffersHaveExpiredException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class SomeOffersHaveExpiredException {
            @Override
            public void write(JsonWriter out, SomeOffersHaveExpiredException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class SomeOffersHaveExpiredException {
            public SomeOffersHaveExpiredException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             SomeOffersHaveExpiredException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/TermLoanOfferTerms.java
+++ b/java/src/main/java/com/kanmon/client/model/TermLoanOfferTerms.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -192,6 +192,50 @@ public class TermLoanOfferTerms {
     this.feePercentage = feePercentage;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the TermLoanOfferTerms instance itself
+   */
+  public TermLoanOfferTerms putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -208,12 +252,13 @@ public class TermLoanOfferTerms {
         Objects.equals(this.loanAmountCents, termLoanOfferTerms.loanAmountCents) &&
         Objects.equals(this.interestRatePercentage, termLoanOfferTerms.interestRatePercentage) &&
         Objects.equals(this.durationMonths, termLoanOfferTerms.durationMonths) &&
-        Objects.equals(this.feePercentage, termLoanOfferTerms.feePercentage);
+        Objects.equals(this.feePercentage, termLoanOfferTerms.feePercentage)&&
+        Objects.equals(this.additionalProperties, termLoanOfferTerms.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productType, maxLoanAmountCents, loanAmountCents, interestRatePercentage, durationMonths, feePercentage);
+    return Objects.hash(productType, maxLoanAmountCents, loanAmountCents, interestRatePercentage, durationMonths, feePercentage, additionalProperties);
   }
 
   @Override
@@ -226,6 +271,7 @@ public class TermLoanOfferTerms {
     sb.append("    interestRatePercentage: ").append(toIndentedString(interestRatePercentage)).append("\n");
     sb.append("    durationMonths: ").append(toIndentedString(durationMonths)).append("\n");
     sb.append("    feePercentage: ").append(toIndentedString(feePercentage)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -278,14 +324,6 @@ public class TermLoanOfferTerms {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!TermLoanOfferTerms.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `TermLoanOfferTerms` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : TermLoanOfferTerms.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -312,6 +350,28 @@ public class TermLoanOfferTerms {
            @Override
            public void write(JsonWriter out, TermLoanOfferTerms value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -319,7 +379,28 @@ public class TermLoanOfferTerms {
            public TermLoanOfferTerms read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             TermLoanOfferTerms instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/TermLoanServicingData.java
+++ b/java/src/main/java/com/kanmon/client/model/TermLoanServicingData.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -215,6 +215,50 @@ public class TermLoanServicingData {
     this.nextPaymentDate = nextPaymentDate;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the TermLoanServicingData instance itself
+   */
+  public TermLoanServicingData putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -232,12 +276,13 @@ public class TermLoanServicingData {
         Objects.equals(this.principalBalanceCents, termLoanServicingData.principalBalanceCents) &&
         Objects.equals(this.monthlyPaymentCents, termLoanServicingData.monthlyPaymentCents) &&
         Objects.equals(this.interestRate, termLoanServicingData.interestRate) &&
-        Objects.equals(this.nextPaymentDate, termLoanServicingData.nextPaymentDate);
+        Objects.equals(this.nextPaymentDate, termLoanServicingData.nextPaymentDate)&&
+        Objects.equals(this.additionalProperties, termLoanServicingData.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productType, loanAmountCents, originationFeeCents, principalBalanceCents, monthlyPaymentCents, interestRate, nextPaymentDate);
+    return Objects.hash(productType, loanAmountCents, originationFeeCents, principalBalanceCents, monthlyPaymentCents, interestRate, nextPaymentDate, additionalProperties);
   }
 
   @Override
@@ -251,6 +296,7 @@ public class TermLoanServicingData {
     sb.append("    monthlyPaymentCents: ").append(toIndentedString(monthlyPaymentCents)).append("\n");
     sb.append("    interestRate: ").append(toIndentedString(interestRate)).append("\n");
     sb.append("    nextPaymentDate: ").append(toIndentedString(nextPaymentDate)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -305,14 +351,6 @@ public class TermLoanServicingData {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!TermLoanServicingData.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `TermLoanServicingData` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : TermLoanServicingData.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -342,6 +380,28 @@ public class TermLoanServicingData {
            @Override
            public void write(JsonWriter out, TermLoanServicingData value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -349,7 +409,28 @@ public class TermLoanServicingData {
            public TermLoanServicingData read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             TermLoanServicingData instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/UnmergeableBusinessException.java
+++ b/java/src/main/java/com/kanmon/client/model/UnmergeableBusinessException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class UnmergeableBusinessException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the UnmergeableBusinessException instance itself
+   */
+  public UnmergeableBusinessException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class UnmergeableBusinessException {
     UnmergeableBusinessException unmergeableBusinessException = (UnmergeableBusinessException) o;
     return Objects.equals(this.errorCode, unmergeableBusinessException.errorCode) &&
         Objects.equals(this.message, unmergeableBusinessException.message) &&
-        Objects.equals(this.timestamp, unmergeableBusinessException.timestamp);
+        Objects.equals(this.timestamp, unmergeableBusinessException.timestamp)&&
+        Objects.equals(this.additionalProperties, unmergeableBusinessException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class UnmergeableBusinessException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class UnmergeableBusinessException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!UnmergeableBusinessException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `UnmergeableBusinessException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : UnmergeableBusinessException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class UnmergeableBusinessException {
            @Override
            public void write(JsonWriter out, UnmergeableBusinessException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class UnmergeableBusinessException {
            public UnmergeableBusinessException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             UnmergeableBusinessException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/UpdateBusinessAccountRequestBody.java
+++ b/java/src/main/java/com/kanmon/client/model/UpdateBusinessAccountRequestBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -144,6 +144,50 @@ public class UpdateBusinessAccountRequestBody {
     this.routingNumber = routingNumber;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the UpdateBusinessAccountRequestBody instance itself
+   */
+  public UpdateBusinessAccountRequestBody putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -158,12 +202,13 @@ public class UpdateBusinessAccountRequestBody {
     return Objects.equals(this.platformBankAccountId, updateBusinessAccountRequestBody.platformBankAccountId) &&
         Objects.equals(this.accountName, updateBusinessAccountRequestBody.accountName) &&
         Objects.equals(this.accountNumber, updateBusinessAccountRequestBody.accountNumber) &&
-        Objects.equals(this.routingNumber, updateBusinessAccountRequestBody.routingNumber);
+        Objects.equals(this.routingNumber, updateBusinessAccountRequestBody.routingNumber)&&
+        Objects.equals(this.additionalProperties, updateBusinessAccountRequestBody.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(platformBankAccountId, accountName, accountNumber, routingNumber);
+    return Objects.hash(platformBankAccountId, accountName, accountNumber, routingNumber, additionalProperties);
   }
 
   @Override
@@ -174,6 +219,7 @@ public class UpdateBusinessAccountRequestBody {
     sb.append("    accountName: ").append(toIndentedString(accountName)).append("\n");
     sb.append("    accountNumber: ").append(toIndentedString(accountNumber)).append("\n");
     sb.append("    routingNumber: ").append(toIndentedString(routingNumber)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -217,14 +263,6 @@ public class UpdateBusinessAccountRequestBody {
           throw new IllegalArgumentException(String.format("The required field(s) %s in UpdateBusinessAccountRequestBody is not found in the empty JSON string", UpdateBusinessAccountRequestBody.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!UpdateBusinessAccountRequestBody.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `UpdateBusinessAccountRequestBody` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("platformBankAccountId") != null && !jsonObj.get("platformBankAccountId").isJsonNull()) && !jsonObj.get("platformBankAccountId").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `platformBankAccountId` to be a primitive type in the JSON string but got `%s`", jsonObj.get("platformBankAccountId").toString()));
@@ -255,6 +293,28 @@ public class UpdateBusinessAccountRequestBody {
            @Override
            public void write(JsonWriter out, UpdateBusinessAccountRequestBody value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -262,7 +322,28 @@ public class UpdateBusinessAccountRequestBody {
            public UpdateBusinessAccountRequestBody read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             UpdateBusinessAccountRequestBody instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/UpdateBusinessRequestBody.java
+++ b/java/src/main/java/com/kanmon/client/model/UpdateBusinessRequestBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -260,6 +260,50 @@ public class UpdateBusinessRequestBody {
     this.isSoleProprietorship = isSoleProprietorship;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the UpdateBusinessRequestBody instance itself
+   */
+  public UpdateBusinessRequestBody putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -279,12 +323,13 @@ public class UpdateBusinessRequestBody {
         Objects.equals(this.website, updateBusinessRequestBody.website) &&
         Objects.equals(this.customInitializationName, updateBusinessRequestBody.customInitializationName) &&
         Objects.equals(this.metadata, updateBusinessRequestBody.metadata) &&
-        Objects.equals(this.isSoleProprietorship, updateBusinessRequestBody.isSoleProprietorship);
+        Objects.equals(this.isSoleProprietorship, updateBusinessRequestBody.isSoleProprietorship)&&
+        Objects.equals(this.additionalProperties, updateBusinessRequestBody.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, platformBusinessId, address, ein, phoneNumber, website, customInitializationName, metadata, isSoleProprietorship);
+    return Objects.hash(name, platformBusinessId, address, ein, phoneNumber, website, customInitializationName, metadata, isSoleProprietorship, additionalProperties);
   }
 
   @Override
@@ -300,6 +345,7 @@ public class UpdateBusinessRequestBody {
     sb.append("    customInitializationName: ").append(toIndentedString(customInitializationName)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("    isSoleProprietorship: ").append(toIndentedString(isSoleProprietorship)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -348,14 +394,6 @@ public class UpdateBusinessRequestBody {
           throw new IllegalArgumentException(String.format("The required field(s) %s in UpdateBusinessRequestBody is not found in the empty JSON string", UpdateBusinessRequestBody.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!UpdateBusinessRequestBody.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `UpdateBusinessRequestBody` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
@@ -393,6 +431,28 @@ public class UpdateBusinessRequestBody {
            @Override
            public void write(JsonWriter out, UpdateBusinessRequestBody value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -400,7 +460,28 @@ public class UpdateBusinessRequestBody {
            public UpdateBusinessRequestBody read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             UpdateBusinessRequestBody instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/UpdateUser409Response.java
+++ b/java/src/main/java/com/kanmon/client/model/UpdateUser409Response.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/java/src/main/java/com/kanmon/client/model/UpdateUserRequestBody.java
+++ b/java/src/main/java/com/kanmon/client/model/UpdateUserRequestBody.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -78,9 +78,9 @@ public class UpdateUserRequestBody {
    */
   @JsonAdapter(RolesEnum.Adapter.class)
   public enum RolesEnum {
-    OPERATOR("OPERATOR"),
+    PRIMARY_OWNER("PRIMARY_OWNER"),
     
-    PRIMARY_OWNER("PRIMARY_OWNER");
+    OPERATOR("OPERATOR");
 
     private String value;
 
@@ -245,7 +245,7 @@ public class UpdateUserRequestBody {
   }
 
   /**
-   * The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. &lt;br/&gt;&lt;br/&gt;A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. &lt;br/&gt;&lt;br/&gt;An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. &lt;br /&gt;&lt;br/&gt;Please note Kanmon supports an additional user role called secondary owners. Secondary owners are beneficial owners of a business, like primary owners, and Kanmon must perform KYC checks for these users. Kanmon will handle creating and managing these users for KYC purposes through a separate process. &lt;br/&gt;
+   * The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. &lt;br/&gt;&lt;br/&gt;A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. &lt;br/&gt;&lt;br/&gt;An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. &lt;br /&gt;&lt;br/&gt;A secondary owner is a beneficial owner of the business who must complete KYC. This means the user can sign financing agreements when required and service an active issued product. During onboarding, the primary owner invites secondary owners. Secondary owners are directed to a separate Kanmon-hosted page where they complete onboarding, sign legal documents, and KYC. They can also access servicing from that page. Kanmon sends a &#x60;USER.CREATED&#x60; webhook when a secondary owner is created.
    * @return roles
    */
   @javax.annotation.Nullable
@@ -276,6 +276,50 @@ public class UpdateUserRequestBody {
     this.metadata = metadata;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the UpdateUserRequestBody instance itself
+   */
+  public UpdateUserRequestBody putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -293,12 +337,13 @@ public class UpdateUserRequestBody {
         Objects.equals(this.address, updateUserRequestBody.address) &&
         Objects.equals(this.email, updateUserRequestBody.email) &&
         Objects.equals(this.roles, updateUserRequestBody.roles) &&
-        Objects.equals(this.metadata, updateUserRequestBody.metadata);
+        Objects.equals(this.metadata, updateUserRequestBody.metadata)&&
+        Objects.equals(this.additionalProperties, updateUserRequestBody.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(firstName, lastName, phoneNumber, address, email, roles, metadata);
+    return Objects.hash(firstName, lastName, phoneNumber, address, email, roles, metadata, additionalProperties);
   }
 
   @Override
@@ -312,6 +357,7 @@ public class UpdateUserRequestBody {
     sb.append("    email: ").append(toIndentedString(email)).append("\n");
     sb.append("    roles: ").append(toIndentedString(roles)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -358,14 +404,6 @@ public class UpdateUserRequestBody {
           throw new IllegalArgumentException(String.format("The required field(s) %s in UpdateUserRequestBody is not found in the empty JSON string", UpdateUserRequestBody.openapiRequiredFields.toString()));
         }
       }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!UpdateUserRequestBody.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `UpdateUserRequestBody` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
       if ((jsonObj.get("firstName") != null && !jsonObj.get("firstName").isJsonNull()) && !jsonObj.get("firstName").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `firstName` to be a primitive type in the JSON string but got `%s`", jsonObj.get("firstName").toString()));
@@ -404,6 +442,28 @@ public class UpdateUserRequestBody {
            @Override
            public void write(JsonWriter out, UpdateUserRequestBody value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -411,7 +471,28 @@ public class UpdateUserRequestBody {
            public UpdateUserRequestBody read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             UpdateUserRequestBody instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/User.java
+++ b/java/src/main/java/com/kanmon/client/model/User.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -97,7 +97,9 @@ public class User {
   public enum RolesEnum {
     PRIMARY_OWNER("PRIMARY_OWNER"),
     
-    OPERATOR("OPERATOR");
+    OPERATOR("OPERATOR"),
+    
+    SECONDARY_OWNER("SECONDARY_OWNER");
 
     private String value;
 
@@ -350,7 +352,7 @@ public class User {
   }
 
   /**
-   * The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. &lt;br/&gt;&lt;br/&gt;A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. &lt;br/&gt;&lt;br/&gt;An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. &lt;br /&gt;&lt;br/&gt;Please note Kanmon supports an additional user role called secondary owners. Secondary owners are beneficial owners of a business, like primary owners, and Kanmon must perform KYC checks for these users. Kanmon will handle creating and managing these users for KYC purposes through a separate process. &lt;br/&gt;
+   * The user’s roles. &lt;br/&gt;&lt;br/&gt;A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. &lt;br/&gt;&lt;br/&gt;An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. &lt;br /&gt;&lt;br/&gt;A secondary owner is a beneficial owner of the business who must complete KYC. This means the user can sign financing agreements when required and service an active issued product. During onboarding, the primary owner invites secondary owners. Secondary owners are directed to a separate Kanmon-hosted page where they complete onboarding, sign legal documents, and KYC. They can also access servicing from that page. Kanmon sends a &#x60;USER.CREATED&#x60; webhook when a secondary owner is created.
    * @return roles
    */
   @javax.annotation.Nullable
@@ -438,6 +440,50 @@ public class User {
     this.updatedAt = updatedAt;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the User instance itself
+   */
+  public User putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -462,7 +508,8 @@ public class User {
         Objects.equals(this.metadata, user.metadata) &&
         Objects.equals(this.isUsCitizen, user.isUsCitizen) &&
         Objects.equals(this.createdAt, user.createdAt) &&
-        Objects.equals(this.updatedAt, user.updatedAt);
+        Objects.equals(this.updatedAt, user.updatedAt)&&
+        Objects.equals(this.additionalProperties, user.additionalProperties);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -471,7 +518,7 @@ public class User {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, platformUserId, platformBusinessId, phoneNumber, businessId, address, email, firstName, lastName, roles, metadata, isUsCitizen, createdAt, updatedAt);
+    return Objects.hash(id, platformUserId, platformBusinessId, phoneNumber, businessId, address, email, firstName, lastName, roles, metadata, isUsCitizen, createdAt, updatedAt, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -499,6 +546,7 @@ public class User {
     sb.append("    isUsCitizen: ").append(toIndentedString(isUsCitizen)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
     sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -558,14 +606,6 @@ public class User {
       if (jsonElement == null) {
         if (!User.openapiRequiredFields.isEmpty()) { // has required fields but JSON element is null
           throw new IllegalArgumentException(String.format("The required field(s) %s in User is not found in the empty JSON string", User.openapiRequiredFields.toString()));
-        }
-      }
-
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!User.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `User` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
         }
       }
 
@@ -629,6 +669,28 @@ public class User {
            @Override
            public void write(JsonWriter out, User value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -636,7 +698,28 @@ public class User {
            public User read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             User instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/UserAlreadyExistsWithEmailException.java
+++ b/java/src/main/java/com/kanmon/client/model/UserAlreadyExistsWithEmailException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class UserAlreadyExistsWithEmailException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the UserAlreadyExistsWithEmailException instance itself
+   */
+  public UserAlreadyExistsWithEmailException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class UserAlreadyExistsWithEmailException {
     UserAlreadyExistsWithEmailException userAlreadyExistsWithEmailException = (UserAlreadyExistsWithEmailException) o;
     return Objects.equals(this.errorCode, userAlreadyExistsWithEmailException.errorCode) &&
         Objects.equals(this.message, userAlreadyExistsWithEmailException.message) &&
-        Objects.equals(this.timestamp, userAlreadyExistsWithEmailException.timestamp);
+        Objects.equals(this.timestamp, userAlreadyExistsWithEmailException.timestamp)&&
+        Objects.equals(this.additionalProperties, userAlreadyExistsWithEmailException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class UserAlreadyExistsWithEmailException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class UserAlreadyExistsWithEmailException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!UserAlreadyExistsWithEmailException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `UserAlreadyExistsWithEmailException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : UserAlreadyExistsWithEmailException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class UserAlreadyExistsWithEmailException {
            @Override
            public void write(JsonWriter out, UserAlreadyExistsWithEmailException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class UserAlreadyExistsWithEmailException {
            public UserAlreadyExistsWithEmailException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             UserAlreadyExistsWithEmailException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/UserAlreadyExistsWithPlatformUserIdException.java
+++ b/java/src/main/java/com/kanmon/client/model/UserAlreadyExistsWithPlatformUserIdException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class UserAlreadyExistsWithPlatformUserIdException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the UserAlreadyExistsWithPlatformUserIdException instance itself
+   */
+  public UserAlreadyExistsWithPlatformUserIdException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class UserAlreadyExistsWithPlatformUserIdException {
     UserAlreadyExistsWithPlatformUserIdException userAlreadyExistsWithPlatformUserIdException = (UserAlreadyExistsWithPlatformUserIdException) o;
     return Objects.equals(this.errorCode, userAlreadyExistsWithPlatformUserIdException.errorCode) &&
         Objects.equals(this.message, userAlreadyExistsWithPlatformUserIdException.message) &&
-        Objects.equals(this.timestamp, userAlreadyExistsWithPlatformUserIdException.timestamp);
+        Objects.equals(this.timestamp, userAlreadyExistsWithPlatformUserIdException.timestamp)&&
+        Objects.equals(this.additionalProperties, userAlreadyExistsWithPlatformUserIdException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class UserAlreadyExistsWithPlatformUserIdException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class UserAlreadyExistsWithPlatformUserIdException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!UserAlreadyExistsWithPlatformUserIdException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `UserAlreadyExistsWithPlatformUserIdException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : UserAlreadyExistsWithPlatformUserIdException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class UserAlreadyExistsWithPlatformUserIdException {
            @Override
            public void write(JsonWriter out, UserAlreadyExistsWithPlatformUserIdException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class UserAlreadyExistsWithPlatformUserIdException {
            public UserAlreadyExistsWithPlatformUserIdException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             UserAlreadyExistsWithPlatformUserIdException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/main/java/com/kanmon/client/model/UserNotFoundException.java
+++ b/java/src/main/java/com/kanmon/client/model/UserNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -171,6 +171,50 @@ public class UserNotFoundException {
     this.timestamp = timestamp;
   }
 
+  /**
+   * A container for additional, undeclared properties.
+   * This is a holder for any undeclared properties as specified with
+   * the 'additionalProperties' keyword in the OAS document.
+   */
+  private Map<String, Object> additionalProperties;
+
+  /**
+   * Set the additional (undeclared) property with the specified name and value.
+   * If the property does not already exist, create it otherwise replace it.
+   *
+   * @param key name of the property
+   * @param value value of the property
+   * @return the UserNotFoundException instance itself
+   */
+  public UserNotFoundException putAdditionalProperty(String key, Object value) {
+    if (this.additionalProperties == null) {
+        this.additionalProperties = new HashMap<String, Object>();
+    }
+    this.additionalProperties.put(key, value);
+    return this;
+  }
+
+  /**
+   * Return the additional (undeclared) property.
+   *
+   * @return a map of objects
+   */
+  public Map<String, Object> getAdditionalProperties() {
+    return additionalProperties;
+  }
+
+  /**
+   * Return the additional (undeclared) property with the specified name.
+   *
+   * @param key name of the property
+   * @return an object
+   */
+  public Object getAdditionalProperty(String key) {
+    if (this.additionalProperties == null) {
+        return null;
+    }
+    return this.additionalProperties.get(key);
+  }
 
 
   @Override
@@ -184,12 +228,13 @@ public class UserNotFoundException {
     UserNotFoundException userNotFoundException = (UserNotFoundException) o;
     return Objects.equals(this.errorCode, userNotFoundException.errorCode) &&
         Objects.equals(this.message, userNotFoundException.message) &&
-        Objects.equals(this.timestamp, userNotFoundException.timestamp);
+        Objects.equals(this.timestamp, userNotFoundException.timestamp)&&
+        Objects.equals(this.additionalProperties, userNotFoundException.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorCode, message, timestamp);
+    return Objects.hash(errorCode, message, timestamp, additionalProperties);
   }
 
   @Override
@@ -199,6 +244,7 @@ public class UserNotFoundException {
     sb.append("    errorCode: ").append(toIndentedString(errorCode)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
     sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -245,14 +291,6 @@ public class UserNotFoundException {
         }
       }
 
-      Set<Map.Entry<String, JsonElement>> entries = jsonElement.getAsJsonObject().entrySet();
-      // check to see if the JSON string contains additional fields
-      for (Map.Entry<String, JsonElement> entry : entries) {
-        if (!UserNotFoundException.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field `%s` in the JSON string is not defined in the `UserNotFoundException` properties. JSON: %s", entry.getKey(), jsonElement.toString()));
-        }
-      }
-
       // check to make sure all required properties/fields are present in the JSON string
       for (String requiredField : UserNotFoundException.openapiRequiredFields) {
         if (jsonElement.getAsJsonObject().get(requiredField) == null) {
@@ -288,6 +326,28 @@ public class UserNotFoundException {
            @Override
            public void write(JsonWriter out, UserNotFoundException value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             obj.remove("additionalProperties");
+             // serialize additional properties
+             if (value.getAdditionalProperties() != null) {
+               for (Map.Entry<String, Object> entry : value.getAdditionalProperties().entrySet()) {
+                 if (entry.getValue() instanceof String)
+                   obj.addProperty(entry.getKey(), (String) entry.getValue());
+                 else if (entry.getValue() instanceof Number)
+                   obj.addProperty(entry.getKey(), (Number) entry.getValue());
+                 else if (entry.getValue() instanceof Boolean)
+                   obj.addProperty(entry.getKey(), (Boolean) entry.getValue());
+                 else if (entry.getValue() instanceof Character)
+                   obj.addProperty(entry.getKey(), (Character) entry.getValue());
+                 else {
+                   JsonElement jsonElement = gson.toJsonTree(entry.getValue());
+                   if (jsonElement.isJsonArray()) {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonArray());
+                   } else {
+                     obj.add(entry.getKey(), jsonElement.getAsJsonObject());
+                   }
+                 }
+               }
+             }
              elementAdapter.write(out, obj);
            }
 
@@ -295,7 +355,28 @@ public class UserNotFoundException {
            public UserNotFoundException read(JsonReader in) throws IOException {
              JsonElement jsonElement = elementAdapter.read(in);
              validateJsonElement(jsonElement);
-             return thisAdapter.fromJsonTree(jsonElement);
+             JsonObject jsonObj = jsonElement.getAsJsonObject();
+             // store additional fields in the deserialized instance
+             UserNotFoundException instance = thisAdapter.fromJsonTree(jsonObj);
+             for (Map.Entry<String, JsonElement> entry : jsonObj.entrySet()) {
+               if (!openapiFields.contains(entry.getKey())) {
+                 if (entry.getValue().isJsonPrimitive()) { // primitive type
+                   if (entry.getValue().getAsJsonPrimitive().isString())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsString());
+                   else if (entry.getValue().getAsJsonPrimitive().isNumber())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsNumber());
+                   else if (entry.getValue().getAsJsonPrimitive().isBoolean())
+                     instance.putAdditionalProperty(entry.getKey(), entry.getValue().getAsBoolean());
+                   else
+                     throw new IllegalArgumentException(String.format("The field `%s` has unknown primitive type. Value: %s", entry.getKey(), entry.getValue().toString()));
+                 } else if (entry.getValue().isJsonArray()) {
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), List.class));
+                 } else { // JSON object
+                     instance.putAdditionalProperty(entry.getKey(), gson.fromJson(entry.getValue(), HashMap.class));
+                 }
+               }
+             }
+             return instance;
            }
 
        }.nullSafe();

--- a/java/src/test/java/com/kanmon/client/api/SandboxUtilitiesApiTest.java
+++ b/java/src/test/java/com/kanmon/client/api/SandboxUtilitiesApiTest.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -42,7 +42,8 @@ public class SandboxUtilitiesApiTest {
     @Test
     public void sandboxDeleteBusinessTest() throws ApiException {
         Object id = null;
-        api.sandboxDeleteBusiness(id);
+        String idType = null;
+        api.sandboxDeleteBusiness(id, idType);
         // TODO: test validations
     }
 
@@ -54,7 +55,8 @@ public class SandboxUtilitiesApiTest {
     @Test
     public void sandboxResetBusinessTest() throws ApiException {
         Object id = null;
-        Business response = api.sandboxResetBusiness(id);
+        String idType = null;
+        Business response = api.sandboxResetBusiness(id, idType);
         // TODO: test validations
     }
 

--- a/java/src/test/java/com/kanmon/client/api/UsersApiTest.java
+++ b/java/src/test/java/com/kanmon/client/api/UsersApiTest.java
@@ -1,6 +1,6 @@
 /*
  * Kanmon Public V2 API
- * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -68,11 +68,12 @@ public class UsersApiTest {
         String platformUserIds = null;
         String platformBusinessIds = null;
         String businessIds = null;
+        Boolean includeSecondaryOwners = null;
         BigDecimal offset = null;
         BigDecimal limit = null;
         String createdAtStart = null;
         String createdAtEnd = null;
-        GetUsersResponse response = api.getAllUsers(ids, platformUserIds, platformBusinessIds, businessIds, offset, limit, createdAtStart, createdAtEnd);
+        GetUsersResponse response = api.getAllUsers(ids, platformUserIds, platformBusinessIds, businessIds, includeSecondaryOwners, offset, limit, createdAtStart, createdAtEnd);
         // TODO: test validations
     }
 

--- a/java/src/test/java/com/kanmon/client/model/RepaymentCadenceTest.java
+++ b/java/src/test/java/com/kanmon/client/model/RepaymentCadenceTest.java
@@ -11,26 +11,22 @@
  */
 
 
-package com.kanmon.client.auth;
+package com.kanmon.client.model;
 
-import com.kanmon.client.Pair;
-import com.kanmon.client.ApiException;
+import com.google.gson.annotations.SerializedName;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import java.net.URI;
-import java.util.Map;
-import java.util.List;
-
-public interface Authentication {
+/**
+ * Model tests for RepaymentCadence
+ */
+public class RepaymentCadenceTest {
     /**
-     * Apply authentication settings to header and query params.
-     *
-     * @param queryParams List of query parameters
-     * @param headerParams Map of header parameters
-     * @param cookieParams Map of cookie parameters
-     * @param payload HTTP request body
-     * @param method HTTP method
-     * @param uri URI
-     * @throws ApiException if failed to update the parameters
+     * Model tests for RepaymentCadence
      */
-    void applyToParams(List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams, String payload, String method, URI uri) throws ApiException;
+    @Test
+    public void testRepaymentCadence() {
+        // TODO: test RepaymentCadence
+    }
+
 }

--- a/kanmon_api_spec.json
+++ b/kanmon_api_spec.json
@@ -84,6 +84,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -173,6 +186,19 @@
                 "schema": {
                   "$ref": "#/components/schemas/BusinessAlreadyExistsException"
                 }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -277,6 +303,19 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ForbiddenException" }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -389,6 +428,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -466,6 +518,19 @@
                 "schema": {
                   "$ref": "#/components/schemas/BusinessNotFoundException"
                 }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -585,6 +650,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -678,6 +756,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -735,8 +826,16 @@
             "required": false,
             "in": "query",
             "description": "A comma delimited list of your Kanmon’s unique business IDs for users.",
-            "example": "767d9894-7214-4a0a-9c4e-ec4a7c70c1e1,e7935095-6ea8-44d9-a5b5-6235a61dc1cf",
+            "example": "d6fb9273-f9c7-4c87-98ed-9a25fc667815,2a124938-fa43-4861-af81-b262c87f9bc4",
             "schema": { "type": "string" }
+          },
+          {
+            "name": "includeSecondaryOwners",
+            "required": false,
+            "in": "query",
+            "description": "When true, secondary owners are included in results alongside other users. When false, secondary owners are excluded from results. Defaults to `false`.",
+            "example": false,
+            "schema": { "type": "boolean" }
           },
           {
             "name": "offset",
@@ -793,6 +892,19 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ForbiddenException" }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -875,6 +987,19 @@
                 "schema": {
                   "$ref": "#/components/schemas/UserNotFoundException"
                 }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -983,6 +1108,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -1069,6 +1207,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -1142,6 +1293,19 @@
                 "schema": {
                   "$ref": "#/components/schemas/UserNotFoundException"
                 }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -1227,6 +1391,19 @@
                     { "$ref": "#/components/schemas/BusinessNotFoundException" }
                   ]
                 }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -1358,6 +1535,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -1409,7 +1599,7 @@
             }
           },
           "400": {
-            "description": "PlatformInvoiceIdAlreadyExistsException, InvoicePaymentPlanNotFoundException, InvalidInvoiceDueDateException, \n        IncorrectFinancingAmountException",
+            "description": "PlatformInvoiceIdAlreadyExistsException, InvoicePaymentPlanNotFoundException, InvalidInvoiceDueDateException,\n        IncorrectFinancingAmountException",
             "content": {
               "application/json": {
                 "schema": {
@@ -1473,6 +1663,19 @@
                     }
                   ]
                 }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -1547,6 +1750,19 @@
                 "schema": {
                   "$ref": "#/components/schemas/OfferNotFoundException"
                 }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -1662,6 +1878,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -1733,6 +1962,19 @@
                 "schema": {
                   "$ref": "#/components/schemas/IssuedProductNotFoundException"
                 }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -1858,6 +2100,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -1944,6 +2199,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -2002,7 +2270,7 @@
             "required": false,
             "in": "query",
             "description": "A comma delimited list of your Kanmon’s unique business IDs for bannk accounts.",
-            "example": "7d632bf1-8537-4c93-bc4a-f485a789f95e,1f05fd2d-2140-41c4-b294-5e0b0196cb6f",
+            "example": "4376bbac-7e0d-4e9a-9c34-a231effbee26,7fc8f162-c95c-4e11-af88-5e4aef993bf1",
             "schema": { "type": "string" }
           },
           {
@@ -2062,6 +2330,19 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ForbiddenException" }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -2145,6 +2426,19 @@
                 "schema": {
                   "$ref": "#/components/schemas/BankAccountNotFoundException"
                 }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -2239,6 +2533,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -2313,6 +2620,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -2348,7 +2668,7 @@
             "required": false,
             "in": "query",
             "description": "A comma delimited list of Kanmon’s unique draw request IDs.",
-            "example": "95dbeab9-f94f-460d-85b8-a50b7bb0b136,782ec087-24f5-40d9-91d4-d005b7d06c14",
+            "example": "358ff585-7021-4d03-bf63-9446a1506e59,03e3c306-6257-4edf-804f-8cc46b0148f9",
             "schema": { "type": "string" }
           },
           {
@@ -2448,6 +2768,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -2519,6 +2852,19 @@
                 "schema": {
                   "$ref": "#/components/schemas/DrawRequestNotFoundException"
                 }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -2644,6 +2990,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -2708,6 +3067,19 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ForbiddenException" }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -2825,6 +3197,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -2927,6 +3312,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -3013,6 +3411,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -3085,6 +3496,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -3133,6 +3557,7 @@
           }
         ],
         "responses": {
+          "204": { "description": "" },
           "400": {
             "description": "BadRequestException",
             "content": {
@@ -3146,6 +3571,19 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ForbiddenException" }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
               }
             }
           },
@@ -3242,6 +3680,19 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests. Returned when rate limiting applies to this platform and the request limit has been exceeded.",
+            "headers": {
+              "X-RateLimit-Limit": {
+                "description": "Maximum number of requests allowed per minute.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Number of remaining requests available.",
+                "schema": { "type": "integer" }
+              }
+            }
+          },
           "500": {
             "description": "InternalServerErrorException",
             "content": {
@@ -3260,7 +3711,7 @@
   },
   "info": {
     "title": "Kanmon Public V2 API",
-    "description": "Kanmon's public api. Contains all of the endpoints for both capital providers and platforms",
+    "description": "Kanmon's public api. Contains all of the endpoints for both capital providers and platforms.\n\n## Rate limiting\n\nEndpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:\n\n- `X-RateLimit-Limit` — maximum requests allowed per minute.\n- `X-RateLimit-Remaining` — requests remaining in the current window.\n\nWhen the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.",
     "version": "2.0.0",
     "contact": {}
   },
@@ -3902,7 +4353,7 @@
           },
           "roles": {
             "type": "array",
-            "description": "The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. <br/><br/>A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. <br/><br/>An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. <br /><br/>Please note Kanmon supports an additional user role called secondary owners. Secondary owners are beneficial owners of a business, like primary owners, and Kanmon must perform KYC checks for these users. Kanmon will handle creating and managing these users for KYC purposes through a separate process. <br/>",
+            "description": "The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. <br/><br/>A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. <br/><br/>An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. <br /><br/>A secondary owner is a beneficial owner of the business who must complete KYC. This means the user can sign financing agreements when required and service an active issued product. During onboarding, the primary owner invites secondary owners. Secondary owners are directed to a separate Kanmon-hosted page where they complete onboarding, sign legal documents, and KYC. They can also access servicing from that page. Kanmon sends a `USER.CREATED` webhook when a secondary owner is created.",
             "example": ["PRIMARY_OWNER"],
             "items": { "type": "string", "enum": ["PRIMARY_OWNER", "OPERATOR"] }
           },
@@ -3929,7 +4380,8 @@
           "platformUserId": {
             "type": "string",
             "description": "Your platform’s unique ID for the user.",
-            "example": "12345"
+            "example": "12345",
+            "nullable": true
           },
           "platformBusinessId": {
             "type": "string",
@@ -3980,9 +4432,12 @@
           },
           "roles": {
             "type": "array",
-            "description": "The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. <br/><br/>A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. <br/><br/>An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. <br /><br/>Please note Kanmon supports an additional user role called secondary owners. Secondary owners are beneficial owners of a business, like primary owners, and Kanmon must perform KYC checks for these users. Kanmon will handle creating and managing these users for KYC purposes through a separate process. <br/>",
+            "description": "The user’s roles. <br/><br/>A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. <br/><br/>An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. <br /><br/>A secondary owner is a beneficial owner of the business who must complete KYC. This means the user can sign financing agreements when required and service an active issued product. During onboarding, the primary owner invites secondary owners. Secondary owners are directed to a separate Kanmon-hosted page where they complete onboarding, sign legal documents, and KYC. They can also access servicing from that page. Kanmon sends a `USER.CREATED` webhook when a secondary owner is created.",
             "example": ["PRIMARY_OWNER"],
-            "items": { "type": "string", "enum": ["PRIMARY_OWNER", "OPERATOR"] }
+            "items": {
+              "type": "string",
+              "enum": ["PRIMARY_OWNER", "OPERATOR", "SECONDARY_OWNER"]
+            }
           },
           "metadata": {
             "type": "object",
@@ -4088,9 +4543,9 @@
           },
           "roles": {
             "type": "array",
-            "description": "The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. <br/><br/>A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. <br/><br/>An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. <br /><br/>Please note Kanmon supports an additional user role called secondary owners. Secondary owners are beneficial owners of a business, like primary owners, and Kanmon must perform KYC checks for these users. Kanmon will handle creating and managing these users for KYC purposes through a separate process. <br/>",
+            "description": "The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. <br/><br/>A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. <br/><br/>An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. <br /><br/>A secondary owner is a beneficial owner of the business who must complete KYC. This means the user can sign financing agreements when required and service an active issued product. During onboarding, the primary owner invites secondary owners. Secondary owners are directed to a separate Kanmon-hosted page where they complete onboarding, sign legal documents, and KYC. They can also access servicing from that page. Kanmon sends a `USER.CREATED` webhook when a secondary owner is created.",
             "example": ["PRIMARY_OWNER"],
-            "items": { "type": "string", "enum": ["OPERATOR", "PRIMARY_OWNER"] }
+            "items": { "type": "string", "enum": ["PRIMARY_OWNER", "OPERATOR"] }
           },
           "metadata": {
             "type": "object",
@@ -4861,6 +5316,7 @@
           "feeAmountCents"
         ]
       },
+      "RepaymentCadence": { "type": "string", "enum": ["WEEKLY", "MONTHLY"] },
       "LineOfCreditOfferTerms": {
         "type": "object",
         "properties": {
@@ -4885,7 +5341,22 @@
           },
           "repaymentDurationMonths": {
             "type": "number",
-            "description": "The duration of the repayment for each draw - in months.",
+            "description": "The duration of the repayment for each draw - in months. Deprecated: use `numPaymentPeriods` and `repaymentCadence` instead.",
+            "example": 3,
+            "deprecated": true
+          },
+          "repaymentCadence": {
+            "example": "MONTHLY",
+            "$ref": "#/components/schemas/RepaymentCadence"
+          },
+          "gracePeriodDays": {
+            "type": "number",
+            "description": "The number of days after each draw during which no installment payments are due. Interest still accrues.",
+            "example": 30
+          },
+          "numPaymentPeriods": {
+            "type": "number",
+            "description": "The number of installment payment periods for each draw.",
             "example": 3
           }
         },
@@ -4894,7 +5365,10 @@
           "totalLimitCents",
           "interestRatePercentage",
           "feePercentage",
-          "repaymentDurationMonths"
+          "repaymentDurationMonths",
+          "repaymentCadence",
+          "gracePeriodDays",
+          "numPaymentPeriods"
         ]
       },
       "IntegratedMcaOfferTerms": {
@@ -5308,7 +5782,22 @@
           },
           "repaymentDurationMonths": {
             "type": "number",
-            "description": "The duration of the repayment for each draw - in months.",
+            "description": "The duration of the repayment for each draw - in months. Deprecated: use `numPaymentPeriods` and `repaymentCadence` instead.",
+            "example": 3,
+            "deprecated": true
+          },
+          "repaymentCadence": {
+            "example": "MONTHLY",
+            "$ref": "#/components/schemas/RepaymentCadence"
+          },
+          "gracePeriodDays": {
+            "type": "number",
+            "description": "The number of days after each draw during which no installment payments are due. Interest still accrues.",
+            "example": 30
+          },
+          "numPaymentPeriods": {
+            "type": "number",
+            "description": "The number of installment payment periods for each draw.",
             "example": 3
           }
         },
@@ -5318,7 +5807,10 @@
           "availableLimitCents",
           "interestRatePercentage",
           "feePercentage",
-          "repaymentDurationMonths"
+          "repaymentDurationMonths",
+          "repaymentCadence",
+          "gracePeriodDays",
+          "numPaymentPeriods"
         ]
       },
       "AccountsPayableFinancingServicingData": {
@@ -5906,8 +6398,28 @@
           },
           "repaymentDurationMonths": {
             "type": "number",
-            "description": "The duration of the repayment for the draw request - in months.",
-            "example": 6
+            "description": "The duration of the repayment for the draw request - in months. Deprecated: use `numPaymentPeriods` and `repaymentCadence` instead.",
+            "example": 6,
+            "deprecated": true
+          },
+          "repaymentCadence": {
+            "example": "MONTHLY",
+            "$ref": "#/components/schemas/RepaymentCadence"
+          },
+          "gracePeriodDays": {
+            "type": "number",
+            "description": "The number of days after the draw during which no installment payments are due. Interest still accrues.",
+            "example": 30
+          },
+          "numPaymentPeriods": {
+            "type": "number",
+            "description": "The number of installment payment periods for the draw request.",
+            "example": 3
+          },
+          "remainingBalanceCents": {
+            "type": "number",
+            "description": "The outstanding principal balance on the draw request - in cents. Equal to the original draw amount minus confirmed principal repayments.",
+            "example": 500000
           },
           "createdAt": {
             "type": "string",
@@ -5930,6 +6442,10 @@
           "interestRatePercentage",
           "feePercentage",
           "repaymentDurationMonths",
+          "repaymentCadence",
+          "gracePeriodDays",
+          "numPaymentPeriods",
+          "remainingBalanceCents",
           "createdAt",
           "updatedAt"
         ]

--- a/openapitools.json
+++ b/openapitools.json
@@ -34,7 +34,8 @@
           "library": "okhttp-gson",
           "serializationLibrary": "gson",
           "hideGenerationTimestamp": true,
-          "licenseName": "Proprietary"
+          "licenseName": "Proprietary",
+          "disallowAdditionalPropertiesIfNotPresent": false
         },
         "ignoreFileOverride": "#{cwd}/ignore_file_overrides/.openapi-java-generator-ignore"
       }

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kanmon/sdk",
-  "version": "3.2.2",
+  "version": "4.0.0",
   "description": "Kanmon API client",
   "author": "Kanmon",
   "repository": {

--- a/ts/src/openapi/.openapi-generator/FILES
+++ b/ts/src/openapi/.openapi-generator/FILES
@@ -135,6 +135,7 @@ src/models/PrimaryBusinessOwnerAlreadyExistsForBusinessException.ts
 src/models/PrimaryBusinessOwnerAlreadyExistsWithEmailException.ts
 src/models/PrimaryBusinessOwnerNotFoundException.ts
 src/models/ProductType.ts
+src/models/RepaymentCadence.ts
 src/models/SessionInvoice.ts
 src/models/SessionInvoiceWithInvoiceFile.ts
 src/models/SomeOffersHaveExpiredException.ts

--- a/ts/src/openapi/src/apis/BankAccountsApi.ts
+++ b/ts/src/openapi/src/apis/BankAccountsApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/BusinessesApi.ts
+++ b/ts/src/openapi/src/apis/BusinessesApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/ConnectTokensApi.ts
+++ b/ts/src/openapi/src/apis/ConnectTokensApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/DocumentsApi.ts
+++ b/ts/src/openapi/src/apis/DocumentsApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/DrawRequestsApi.ts
+++ b/ts/src/openapi/src/apis/DrawRequestsApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/EmbeddedSessionsApi.ts
+++ b/ts/src/openapi/src/apis/EmbeddedSessionsApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/IntegratedMCAApi.ts
+++ b/ts/src/openapi/src/apis/IntegratedMCAApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/InvoicesApi.ts
+++ b/ts/src/openapi/src/apis/InvoicesApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/IssuedProductsApi.ts
+++ b/ts/src/openapi/src/apis/IssuedProductsApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/OffersApi.ts
+++ b/ts/src/openapi/src/apis/OffersApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/PaymentsApi.ts
+++ b/ts/src/openapi/src/apis/PaymentsApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/PrequalificationsApi.ts
+++ b/ts/src/openapi/src/apis/PrequalificationsApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/SandboxUtilitiesApi.ts
+++ b/ts/src/openapi/src/apis/SandboxUtilitiesApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/apis/UsersApi.ts
+++ b/ts/src/openapi/src/apis/UsersApi.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -70,6 +70,7 @@ export interface GetAllUsersRequest {
     platformUserIds?: string;
     platformBusinessIds?: string;
     businessIds?: string;
+    includeSecondaryOwners?: boolean;
     offset?: number;
     limit?: number;
     createdAtStart?: string;
@@ -156,6 +157,10 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (requestParameters['businessIds'] != null) {
             queryParameters['businessIds'] = requestParameters['businessIds'];
+        }
+
+        if (requestParameters['includeSecondaryOwners'] != null) {
+            queryParameters['includeSecondaryOwners'] = requestParameters['includeSecondaryOwners'];
         }
 
         if (requestParameters['offset'] != null) {

--- a/ts/src/openapi/src/models/AccountsPayableFinancingOfferTerms.ts
+++ b/ts/src/openapi/src/models/AccountsPayableFinancingOfferTerms.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/AccountsPayableFinancingServicingData.ts
+++ b/ts/src/openapi/src/models/AccountsPayableFinancingServicingData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/AccountsPayableInvoiceFlowSessionTokenData.ts
+++ b/ts/src/openapi/src/models/AccountsPayableInvoiceFlowSessionTokenData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData.ts
+++ b/ts/src/openapi/src/models/AccountsPayableInvoiceFlowWithInvoiceFileSessionTokenData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/AccountsPayableSessionInvoice.ts
+++ b/ts/src/openapi/src/models/AccountsPayableSessionInvoice.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/AccountsPayableSessionInvoiceWithInvoiceFile.ts
+++ b/ts/src/openapi/src/models/AccountsPayableSessionInvoiceWithInvoiceFile.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/ActivityLog.ts
+++ b/ts/src/openapi/src/models/ActivityLog.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/Address.ts
+++ b/ts/src/openapi/src/models/Address.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BadRequestException.ts
+++ b/ts/src/openapi/src/models/BadRequestException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BankAccountAlreadyExistException.ts
+++ b/ts/src/openapi/src/models/BankAccountAlreadyExistException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BankAccountNotFoundException.ts
+++ b/ts/src/openapi/src/models/BankAccountNotFoundException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BankStatementsInvalidException.ts
+++ b/ts/src/openapi/src/models/BankStatementsInvalidException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/Business.ts
+++ b/ts/src/openapi/src/models/Business.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BusinessAlreadyExistsException.ts
+++ b/ts/src/openapi/src/models/BusinessAlreadyExistsException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BusinessBankAccount.ts
+++ b/ts/src/openapi/src/models/BusinessBankAccount.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BusinessDocument.ts
+++ b/ts/src/openapi/src/models/BusinessDocument.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BusinessHasNoAccountsPayableFinancingProductException.ts
+++ b/ts/src/openapi/src/models/BusinessHasNoAccountsPayableFinancingProductException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BusinessHasNoIntegratedMcaProductException.ts
+++ b/ts/src/openapi/src/models/BusinessHasNoIntegratedMcaProductException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BusinessHasNoInvoiceFinancingProductException.ts
+++ b/ts/src/openapi/src/models/BusinessHasNoInvoiceFinancingProductException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BusinessHasNoPrimaryOwnerException.ts
+++ b/ts/src/openapi/src/models/BusinessHasNoPrimaryOwnerException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BusinessNotFoundException.ts
+++ b/ts/src/openapi/src/models/BusinessNotFoundException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BusinessPlaidBankAccountNotFoundException.ts
+++ b/ts/src/openapi/src/models/BusinessPlaidBankAccountNotFoundException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/BusinessPrequalification.ts
+++ b/ts/src/openapi/src/models/BusinessPrequalification.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CheckingAccountRequiredException.ts
+++ b/ts/src/openapi/src/models/CheckingAccountRequiredException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/ConnectToken.ts
+++ b/ts/src/openapi/src/models/ConnectToken.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateBusiness404Response.ts
+++ b/ts/src/openapi/src/models/CreateBusiness404Response.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateBusinessBankAccountRequestBody.ts
+++ b/ts/src/openapi/src/models/CreateBusinessBankAccountRequestBody.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateBusinessDocumentsResponse.ts
+++ b/ts/src/openapi/src/models/CreateBusinessDocumentsResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateBusinessRequestBody.ts
+++ b/ts/src/openapi/src/models/CreateBusinessRequestBody.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateConnectTokenRequestBody.ts
+++ b/ts/src/openapi/src/models/CreateConnectTokenRequestBody.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateEmbeddedSession409Response.ts
+++ b/ts/src/openapi/src/models/CreateEmbeddedSession409Response.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateIntegratedMcaReceivable400Response.ts
+++ b/ts/src/openapi/src/models/CreateIntegratedMcaReceivable400Response.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateIntegratedMcaReceivable409Response.ts
+++ b/ts/src/openapi/src/models/CreateIntegratedMcaReceivable409Response.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateIntegratedMcaReceivableBody.ts
+++ b/ts/src/openapi/src/models/CreateIntegratedMcaReceivableBody.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateSessionTokenRequestBody.ts
+++ b/ts/src/openapi/src/models/CreateSessionTokenRequestBody.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateSessionTokenRequestBodyData.ts
+++ b/ts/src/openapi/src/models/CreateSessionTokenRequestBodyData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateUser409Response.ts
+++ b/ts/src/openapi/src/models/CreateUser409Response.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/CreateUserRequestBody.ts
+++ b/ts/src/openapi/src/models/CreateUserRequestBody.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -75,7 +75,7 @@ export interface CreateUserRequestBody {
      */
     address?: Address;
     /**
-     * The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. <br/><br/>A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. <br/><br/>An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. <br /><br/>Please note Kanmon supports an additional user role called secondary owners. Secondary owners are beneficial owners of a business, like primary owners, and Kanmon must perform KYC checks for these users. Kanmon will handle creating and managing these users for KYC purposes through a separate process. <br/>
+     * The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. <br/><br/>A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. <br/><br/>An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. <br /><br/>A secondary owner is a beneficial owner of the business who must complete KYC. This means the user can sign financing agreements when required and service an active issued product. During onboarding, the primary owner invites secondary owners. Secondary owners are directed to a separate Kanmon-hosted page where they complete onboarding, sign legal documents, and KYC. They can also access servicing from that page. Kanmon sends a `USER.CREATED` webhook when a secondary owner is created.
      * @type {Array<string>}
      * @memberof CreateUserRequestBody
      */

--- a/ts/src/openapi/src/models/CustomInitializationNotFoundException.ts
+++ b/ts/src/openapi/src/models/CustomInitializationNotFoundException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/DrawRequest.ts
+++ b/ts/src/openapi/src/models/DrawRequest.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -19,6 +19,12 @@ import {
     DrawRequestStateFromJSONTyped,
     DrawRequestStateToJSON,
 } from './DrawRequestState';
+import type { RepaymentCadence } from './RepaymentCadence';
+import {
+    RepaymentCadenceFromJSON,
+    RepaymentCadenceFromJSONTyped,
+    RepaymentCadenceToJSON,
+} from './RepaymentCadence';
 
 /**
  * 
@@ -75,11 +81,36 @@ export interface DrawRequest {
      */
     feePercentage: number;
     /**
-     * The duration of the repayment for the draw request - in months.
+     * The duration of the repayment for the draw request - in months. Deprecated: use `numPaymentPeriods` and `repaymentCadence` instead.
+     * @type {number}
+     * @memberof DrawRequest
+     * @deprecated
+     */
+    repaymentDurationMonths: number;
+    /**
+     * 
+     * @type {RepaymentCadence}
+     * @memberof DrawRequest
+     */
+    repaymentCadence: RepaymentCadence;
+    /**
+     * The number of days after the draw during which no installment payments are due. Interest still accrues.
      * @type {number}
      * @memberof DrawRequest
      */
-    repaymentDurationMonths: number;
+    gracePeriodDays: number;
+    /**
+     * The number of installment payment periods for the draw request.
+     * @type {number}
+     * @memberof DrawRequest
+     */
+    numPaymentPeriods: number;
+    /**
+     * The outstanding principal balance on the draw request - in cents. Equal to the original draw amount minus confirmed principal repayments.
+     * @type {number}
+     * @memberof DrawRequest
+     */
+    remainingBalanceCents: number;
     /**
      * Creation UTC ISO 8601 timestamp of the draw request.
      * @type {string}
@@ -109,6 +140,10 @@ export function instanceOfDrawRequest(value: object): value is DrawRequest {
     if (!('interestRatePercentage' in value) || value['interestRatePercentage'] === undefined) return false;
     if (!('feePercentage' in value) || value['feePercentage'] === undefined) return false;
     if (!('repaymentDurationMonths' in value) || value['repaymentDurationMonths'] === undefined) return false;
+    if (!('repaymentCadence' in value) || value['repaymentCadence'] === undefined) return false;
+    if (!('gracePeriodDays' in value) || value['gracePeriodDays'] === undefined) return false;
+    if (!('numPaymentPeriods' in value) || value['numPaymentPeriods'] === undefined) return false;
+    if (!('remainingBalanceCents' in value) || value['remainingBalanceCents'] === undefined) return false;
     if (!('createdAt' in value) || value['createdAt'] === undefined) return false;
     if (!('updatedAt' in value) || value['updatedAt'] === undefined) return false;
     return true;
@@ -133,6 +168,10 @@ export function DrawRequestFromJSONTyped(json: any, ignoreDiscriminator: boolean
         'interestRatePercentage': json['interestRatePercentage'],
         'feePercentage': json['feePercentage'],
         'repaymentDurationMonths': json['repaymentDurationMonths'],
+        'repaymentCadence': RepaymentCadenceFromJSON(json['repaymentCadence']),
+        'gracePeriodDays': json['gracePeriodDays'],
+        'numPaymentPeriods': json['numPaymentPeriods'],
+        'remainingBalanceCents': json['remainingBalanceCents'],
         'createdAt': json['createdAt'],
         'updatedAt': json['updatedAt'],
     };
@@ -153,6 +192,10 @@ export function DrawRequestToJSON(value?: DrawRequest | null): any {
         'interestRatePercentage': value['interestRatePercentage'],
         'feePercentage': value['feePercentage'],
         'repaymentDurationMonths': value['repaymentDurationMonths'],
+        'repaymentCadence': RepaymentCadenceToJSON(value['repaymentCadence']),
+        'gracePeriodDays': value['gracePeriodDays'],
+        'numPaymentPeriods': value['numPaymentPeriods'],
+        'remainingBalanceCents': value['remainingBalanceCents'],
         'createdAt': value['createdAt'],
         'updatedAt': value['updatedAt'],
     };

--- a/ts/src/openapi/src/models/DrawRequestNotFoundException.ts
+++ b/ts/src/openapi/src/models/DrawRequestNotFoundException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/DrawRequestState.ts
+++ b/ts/src/openapi/src/models/DrawRequestState.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/EmbeddedSession.ts
+++ b/ts/src/openapi/src/models/EmbeddedSession.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/FinanceInvoice400Response.ts
+++ b/ts/src/openapi/src/models/FinanceInvoice400Response.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/FinanceInvoice404Response.ts
+++ b/ts/src/openapi/src/models/FinanceInvoice404Response.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/FinanceInvoice409Response.ts
+++ b/ts/src/openapi/src/models/FinanceInvoice409Response.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/FinanceInvoiceRequestBody.ts
+++ b/ts/src/openapi/src/models/FinanceInvoiceRequestBody.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/FixedDateInvoiceRepaymentWindow.ts
+++ b/ts/src/openapi/src/models/FixedDateInvoiceRepaymentWindow.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/FixedDurationInvoiceRepaymentWindow.ts
+++ b/ts/src/openapi/src/models/FixedDurationInvoiceRepaymentWindow.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/ForbiddenException.ts
+++ b/ts/src/openapi/src/models/ForbiddenException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetActivityLogsResponse.ts
+++ b/ts/src/openapi/src/models/GetActivityLogsResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetBusinessBankAccountsResponse.ts
+++ b/ts/src/openapi/src/models/GetBusinessBankAccountsResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetBusinessesResponse.ts
+++ b/ts/src/openapi/src/models/GetBusinessesResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetDrawRequestsResponse.ts
+++ b/ts/src/openapi/src/models/GetDrawRequestsResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetIntegratedMcaPaymentWindowsResponse.ts
+++ b/ts/src/openapi/src/models/GetIntegratedMcaPaymentWindowsResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetIntegratedMcaReceivablesResponse.ts
+++ b/ts/src/openapi/src/models/GetIntegratedMcaReceivablesResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetInvoice404Response.ts
+++ b/ts/src/openapi/src/models/GetInvoice404Response.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetInvoicesResponse.ts
+++ b/ts/src/openapi/src/models/GetInvoicesResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetIssuedProductsResponse.ts
+++ b/ts/src/openapi/src/models/GetIssuedProductsResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetOffersResponse.ts
+++ b/ts/src/openapi/src/models/GetOffersResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetPaymentScheduleResponse.ts
+++ b/ts/src/openapi/src/models/GetPaymentScheduleResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetPrequalificationsResponse.ts
+++ b/ts/src/openapi/src/models/GetPrequalificationsResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/GetUsersResponse.ts
+++ b/ts/src/openapi/src/models/GetUsersResponse.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/IncorrectFinancingAmountException.ts
+++ b/ts/src/openapi/src/models/IncorrectFinancingAmountException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/IncorrectProductTypeException.ts
+++ b/ts/src/openapi/src/models/IncorrectProductTypeException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/IncorrectRepaymentAmountException.ts
+++ b/ts/src/openapi/src/models/IncorrectRepaymentAmountException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InsufficientCreditLimitException.ts
+++ b/ts/src/openapi/src/models/InsufficientCreditLimitException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/IntegratedMcaOfferTerms.ts
+++ b/ts/src/openapi/src/models/IntegratedMcaOfferTerms.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/IntegratedMcaPaymentWindow.ts
+++ b/ts/src/openapi/src/models/IntegratedMcaPaymentWindow.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/IntegratedMcaReceivable.ts
+++ b/ts/src/openapi/src/models/IntegratedMcaReceivable.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/IntegratedMcaReceivableAlreadyExistsException.ts
+++ b/ts/src/openapi/src/models/IntegratedMcaReceivableAlreadyExistsException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/IntegratedMcaServicingData.ts
+++ b/ts/src/openapi/src/models/IntegratedMcaServicingData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InternalServerErrorException.ts
+++ b/ts/src/openapi/src/models/InternalServerErrorException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InvalidInvoiceDueDateException.ts
+++ b/ts/src/openapi/src/models/InvalidInvoiceDueDateException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/Invoice.ts
+++ b/ts/src/openapi/src/models/Invoice.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InvoiceFinancingOfferTerms.ts
+++ b/ts/src/openapi/src/models/InvoiceFinancingOfferTerms.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InvoiceFinancingServicingData.ts
+++ b/ts/src/openapi/src/models/InvoiceFinancingServicingData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InvoiceFlowSessionTokenData.ts
+++ b/ts/src/openapi/src/models/InvoiceFlowSessionTokenData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InvoiceFlowWithInvoiceFileSessionTokenData.ts
+++ b/ts/src/openapi/src/models/InvoiceFlowWithInvoiceFileSessionTokenData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InvoiceNotFoundException.ts
+++ b/ts/src/openapi/src/models/InvoiceNotFoundException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InvoicePaymentPlan.ts
+++ b/ts/src/openapi/src/models/InvoicePaymentPlan.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InvoicePaymentPlanNotFoundException.ts
+++ b/ts/src/openapi/src/models/InvoicePaymentPlanNotFoundException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InvoicePaymentPlanRepaymentWindow.ts
+++ b/ts/src/openapi/src/models/InvoicePaymentPlanRepaymentWindow.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InvoiceRepaymentSchedule.ts
+++ b/ts/src/openapi/src/models/InvoiceRepaymentSchedule.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InvoiceRepaymentScheduleItem.ts
+++ b/ts/src/openapi/src/models/InvoiceRepaymentScheduleItem.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/InvoiceStatus.ts
+++ b/ts/src/openapi/src/models/InvoiceStatus.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/IssuedProduct.ts
+++ b/ts/src/openapi/src/models/IssuedProduct.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/IssuedProductNotFoundException.ts
+++ b/ts/src/openapi/src/models/IssuedProductNotFoundException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/IssuedProductServicingData.ts
+++ b/ts/src/openapi/src/models/IssuedProductServicingData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/IssuedProductStatusNotCurrentException.ts
+++ b/ts/src/openapi/src/models/IssuedProductStatusNotCurrentException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/LineOfCreditOfferTerms.ts
+++ b/ts/src/openapi/src/models/LineOfCreditOfferTerms.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -19,6 +19,12 @@ import {
     ProductTypeFromJSONTyped,
     ProductTypeToJSON,
 } from './ProductType';
+import type { RepaymentCadence } from './RepaymentCadence';
+import {
+    RepaymentCadenceFromJSON,
+    RepaymentCadenceFromJSONTyped,
+    RepaymentCadenceToJSON,
+} from './RepaymentCadence';
 
 /**
  * 
@@ -51,11 +57,30 @@ export interface LineOfCreditOfferTerms {
      */
     feePercentage: number;
     /**
-     * The duration of the repayment for each draw - in months.
+     * The duration of the repayment for each draw - in months. Deprecated: use `numPaymentPeriods` and `repaymentCadence` instead.
+     * @type {number}
+     * @memberof LineOfCreditOfferTerms
+     * @deprecated
+     */
+    repaymentDurationMonths: number;
+    /**
+     * 
+     * @type {RepaymentCadence}
+     * @memberof LineOfCreditOfferTerms
+     */
+    repaymentCadence: RepaymentCadence;
+    /**
+     * The number of days after each draw during which no installment payments are due. Interest still accrues.
      * @type {number}
      * @memberof LineOfCreditOfferTerms
      */
-    repaymentDurationMonths: number;
+    gracePeriodDays: number;
+    /**
+     * The number of installment payment periods for each draw.
+     * @type {number}
+     * @memberof LineOfCreditOfferTerms
+     */
+    numPaymentPeriods: number;
 }
 
 
@@ -69,6 +94,9 @@ export function instanceOfLineOfCreditOfferTerms(value: object): value is LineOf
     if (!('interestRatePercentage' in value) || value['interestRatePercentage'] === undefined) return false;
     if (!('feePercentage' in value) || value['feePercentage'] === undefined) return false;
     if (!('repaymentDurationMonths' in value) || value['repaymentDurationMonths'] === undefined) return false;
+    if (!('repaymentCadence' in value) || value['repaymentCadence'] === undefined) return false;
+    if (!('gracePeriodDays' in value) || value['gracePeriodDays'] === undefined) return false;
+    if (!('numPaymentPeriods' in value) || value['numPaymentPeriods'] === undefined) return false;
     return true;
 }
 
@@ -87,6 +115,9 @@ export function LineOfCreditOfferTermsFromJSONTyped(json: any, ignoreDiscriminat
         'interestRatePercentage': json['interestRatePercentage'],
         'feePercentage': json['feePercentage'],
         'repaymentDurationMonths': json['repaymentDurationMonths'],
+        'repaymentCadence': RepaymentCadenceFromJSON(json['repaymentCadence']),
+        'gracePeriodDays': json['gracePeriodDays'],
+        'numPaymentPeriods': json['numPaymentPeriods'],
     };
 }
 
@@ -101,6 +132,9 @@ export function LineOfCreditOfferTermsToJSON(value?: LineOfCreditOfferTerms | nu
         'interestRatePercentage': value['interestRatePercentage'],
         'feePercentage': value['feePercentage'],
         'repaymentDurationMonths': value['repaymentDurationMonths'],
+        'repaymentCadence': RepaymentCadenceToJSON(value['repaymentCadence']),
+        'gracePeriodDays': value['gracePeriodDays'],
+        'numPaymentPeriods': value['numPaymentPeriods'],
     };
 }
 

--- a/ts/src/openapi/src/models/LineOfCreditServicingData.ts
+++ b/ts/src/openapi/src/models/LineOfCreditServicingData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -19,6 +19,12 @@ import {
     ProductTypeFromJSONTyped,
     ProductTypeToJSON,
 } from './ProductType';
+import type { RepaymentCadence } from './RepaymentCadence';
+import {
+    RepaymentCadenceFromJSON,
+    RepaymentCadenceFromJSONTyped,
+    RepaymentCadenceToJSON,
+} from './RepaymentCadence';
 
 /**
  * 
@@ -57,11 +63,30 @@ export interface LineOfCreditServicingData {
      */
     feePercentage: number;
     /**
-     * The duration of the repayment for each draw - in months.
+     * The duration of the repayment for each draw - in months. Deprecated: use `numPaymentPeriods` and `repaymentCadence` instead.
+     * @type {number}
+     * @memberof LineOfCreditServicingData
+     * @deprecated
+     */
+    repaymentDurationMonths: number;
+    /**
+     * 
+     * @type {RepaymentCadence}
+     * @memberof LineOfCreditServicingData
+     */
+    repaymentCadence: RepaymentCadence;
+    /**
+     * The number of days after each draw during which no installment payments are due. Interest still accrues.
      * @type {number}
      * @memberof LineOfCreditServicingData
      */
-    repaymentDurationMonths: number;
+    gracePeriodDays: number;
+    /**
+     * The number of installment payment periods for each draw.
+     * @type {number}
+     * @memberof LineOfCreditServicingData
+     */
+    numPaymentPeriods: number;
 }
 
 
@@ -76,6 +101,9 @@ export function instanceOfLineOfCreditServicingData(value: object): value is Lin
     if (!('interestRatePercentage' in value) || value['interestRatePercentage'] === undefined) return false;
     if (!('feePercentage' in value) || value['feePercentage'] === undefined) return false;
     if (!('repaymentDurationMonths' in value) || value['repaymentDurationMonths'] === undefined) return false;
+    if (!('repaymentCadence' in value) || value['repaymentCadence'] === undefined) return false;
+    if (!('gracePeriodDays' in value) || value['gracePeriodDays'] === undefined) return false;
+    if (!('numPaymentPeriods' in value) || value['numPaymentPeriods'] === undefined) return false;
     return true;
 }
 
@@ -95,6 +123,9 @@ export function LineOfCreditServicingDataFromJSONTyped(json: any, ignoreDiscrimi
         'interestRatePercentage': json['interestRatePercentage'],
         'feePercentage': json['feePercentage'],
         'repaymentDurationMonths': json['repaymentDurationMonths'],
+        'repaymentCadence': RepaymentCadenceFromJSON(json['repaymentCadence']),
+        'gracePeriodDays': json['gracePeriodDays'],
+        'numPaymentPeriods': json['numPaymentPeriods'],
     };
 }
 
@@ -110,6 +141,9 @@ export function LineOfCreditServicingDataToJSON(value?: LineOfCreditServicingDat
         'interestRatePercentage': value['interestRatePercentage'],
         'feePercentage': value['feePercentage'],
         'repaymentDurationMonths': value['repaymentDurationMonths'],
+        'repaymentCadence': RepaymentCadenceToJSON(value['repaymentCadence']),
+        'gracePeriodDays': value['gracePeriodDays'],
+        'numPaymentPeriods': value['numPaymentPeriods'],
     };
 }
 

--- a/ts/src/openapi/src/models/LoanStatus.ts
+++ b/ts/src/openapi/src/models/LoanStatus.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/McaOfferTerms.ts
+++ b/ts/src/openapi/src/models/McaOfferTerms.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/McaServicingData.ts
+++ b/ts/src/openapi/src/models/McaServicingData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/MergeUsersRequestBody.ts
+++ b/ts/src/openapi/src/models/MergeUsersRequestBody.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/MergeUsersResponseBody.ts
+++ b/ts/src/openapi/src/models/MergeUsersResponseBody.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/MultipleDurationInvoiceRepaymentWindow.ts
+++ b/ts/src/openapi/src/models/MultipleDurationInvoiceRepaymentWindow.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/NoRemainingBalanceException.ts
+++ b/ts/src/openapi/src/models/NoRemainingBalanceException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/Offer.ts
+++ b/ts/src/openapi/src/models/Offer.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/OfferAlreadySelectedException.ts
+++ b/ts/src/openapi/src/models/OfferAlreadySelectedException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/OfferNotFoundException.ts
+++ b/ts/src/openapi/src/models/OfferNotFoundException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/OfferNotLockedException.ts
+++ b/ts/src/openapi/src/models/OfferNotLockedException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/OfferTerms.ts
+++ b/ts/src/openapi/src/models/OfferTerms.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PaginationResult.ts
+++ b/ts/src/openapi/src/models/PaginationResult.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PaymentOrder.ts
+++ b/ts/src/openapi/src/models/PaymentOrder.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PaymentOrderNotFoundException.ts
+++ b/ts/src/openapi/src/models/PaymentOrderNotFoundException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PaymentOrderStatus.ts
+++ b/ts/src/openapi/src/models/PaymentOrderStatus.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PaymentPlanRepaymentSchedule.ts
+++ b/ts/src/openapi/src/models/PaymentPlanRepaymentSchedule.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PaymentPlanRepaymentScheduleItem.ts
+++ b/ts/src/openapi/src/models/PaymentPlanRepaymentScheduleItem.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PaymentScheduleItem.ts
+++ b/ts/src/openapi/src/models/PaymentScheduleItem.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PlaidAssetReportsInvalidException.ts
+++ b/ts/src/openapi/src/models/PlaidAssetReportsInvalidException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PlatformInvoiceIdAlreadyExistsException.ts
+++ b/ts/src/openapi/src/models/PlatformInvoiceIdAlreadyExistsException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException.ts
+++ b/ts/src/openapi/src/models/PlatformInvoiceIdAlreadyExistsForAnotherIssuedProductException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PlatformInvoiceNumberAlreadyExistsForIssuedProductException.ts
+++ b/ts/src/openapi/src/models/PlatformInvoiceNumberAlreadyExistsForIssuedProductException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PrimaryBusinessOwnerAlreadyExistsForBusinessException.ts
+++ b/ts/src/openapi/src/models/PrimaryBusinessOwnerAlreadyExistsForBusinessException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PrimaryBusinessOwnerAlreadyExistsWithEmailException.ts
+++ b/ts/src/openapi/src/models/PrimaryBusinessOwnerAlreadyExistsWithEmailException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/PrimaryBusinessOwnerNotFoundException.ts
+++ b/ts/src/openapi/src/models/PrimaryBusinessOwnerNotFoundException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/ProductType.ts
+++ b/ts/src/openapi/src/models/ProductType.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/RepaymentCadence.ts
+++ b/ts/src/openapi/src/models/RepaymentCadence.ts
@@ -14,19 +14,20 @@
 
 
 /**
- * The type of document that is uploaded.
+ * 
  * @export
  */
-export const BusinessDocumentType = {
-    INVOICE: 'INVOICE'
+export const RepaymentCadence = {
+    WEEKLY: 'WEEKLY',
+    MONTHLY: 'MONTHLY'
 } as const;
-export type BusinessDocumentType = typeof BusinessDocumentType[keyof typeof BusinessDocumentType];
+export type RepaymentCadence = typeof RepaymentCadence[keyof typeof RepaymentCadence];
 
 
-export function instanceOfBusinessDocumentType(value: any): boolean {
-    for (const key in BusinessDocumentType) {
-        if (Object.prototype.hasOwnProperty.call(BusinessDocumentType, key)) {
-            if (BusinessDocumentType[key as keyof typeof BusinessDocumentType] === value) {
+export function instanceOfRepaymentCadence(value: any): boolean {
+    for (const key in RepaymentCadence) {
+        if (Object.prototype.hasOwnProperty.call(RepaymentCadence, key)) {
+            if (RepaymentCadence[key as keyof typeof RepaymentCadence] === value) {
                 return true;
             }
         }
@@ -34,15 +35,15 @@ export function instanceOfBusinessDocumentType(value: any): boolean {
     return false;
 }
 
-export function BusinessDocumentTypeFromJSON(json: any): BusinessDocumentType {
-    return BusinessDocumentTypeFromJSONTyped(json, false);
+export function RepaymentCadenceFromJSON(json: any): RepaymentCadence {
+    return RepaymentCadenceFromJSONTyped(json, false);
 }
 
-export function BusinessDocumentTypeFromJSONTyped(json: any, ignoreDiscriminator: boolean): BusinessDocumentType {
-    return json as BusinessDocumentType;
+export function RepaymentCadenceFromJSONTyped(json: any, ignoreDiscriminator: boolean): RepaymentCadence {
+    return json as RepaymentCadence;
 }
 
-export function BusinessDocumentTypeToJSON(value?: BusinessDocumentType | null): any {
+export function RepaymentCadenceToJSON(value?: RepaymentCadence | null): any {
     return value as any;
 }
 

--- a/ts/src/openapi/src/models/SessionInvoice.ts
+++ b/ts/src/openapi/src/models/SessionInvoice.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/SessionInvoiceWithInvoiceFile.ts
+++ b/ts/src/openapi/src/models/SessionInvoiceWithInvoiceFile.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/SomeOffersHaveExpiredException.ts
+++ b/ts/src/openapi/src/models/SomeOffersHaveExpiredException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/TermLoanOfferTerms.ts
+++ b/ts/src/openapi/src/models/TermLoanOfferTerms.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/TermLoanServicingData.ts
+++ b/ts/src/openapi/src/models/TermLoanServicingData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/UnmergeableBusinessException.ts
+++ b/ts/src/openapi/src/models/UnmergeableBusinessException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/UpdateBusinessAccountRequestBody.ts
+++ b/ts/src/openapi/src/models/UpdateBusinessAccountRequestBody.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/UpdateBusinessRequestBody.ts
+++ b/ts/src/openapi/src/models/UpdateBusinessRequestBody.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/UpdateUser409Response.ts
+++ b/ts/src/openapi/src/models/UpdateUser409Response.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/UpdateUserRequestBody.ts
+++ b/ts/src/openapi/src/models/UpdateUserRequestBody.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -57,7 +57,7 @@ export interface UpdateUserRequestBody {
      */
     email?: string;
     /**
-     * The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. <br/><br/>A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. <br/><br/>An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. <br /><br/>Please note Kanmon supports an additional user role called secondary owners. Secondary owners are beneficial owners of a business, like primary owners, and Kanmon must perform KYC checks for these users. Kanmon will handle creating and managing these users for KYC purposes through a separate process. <br/>
+     * The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. <br/><br/>A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. <br/><br/>An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. <br /><br/>A secondary owner is a beneficial owner of the business who must complete KYC. This means the user can sign financing agreements when required and service an active issued product. During onboarding, the primary owner invites secondary owners. Secondary owners are directed to a separate Kanmon-hosted page where they complete onboarding, sign legal documents, and KYC. They can also access servicing from that page. Kanmon sends a `USER.CREATED` webhook when a secondary owner is created.
      * @type {Array<string>}
      * @memberof UpdateUserRequestBody
      */
@@ -75,8 +75,8 @@ export interface UpdateUserRequestBody {
  * @export
  */
 export const UpdateUserRequestBodyRolesEnum = {
-    OPERATOR: 'OPERATOR',
-    PRIMARY_OWNER: 'PRIMARY_OWNER'
+    PRIMARY_OWNER: 'PRIMARY_OWNER',
+    OPERATOR: 'OPERATOR'
 } as const;
 export type UpdateUserRequestBodyRolesEnum = typeof UpdateUserRequestBodyRolesEnum[keyof typeof UpdateUserRequestBodyRolesEnum];
 

--- a/ts/src/openapi/src/models/User.ts
+++ b/ts/src/openapi/src/models/User.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 
@@ -37,7 +37,7 @@ export interface User {
      * @type {string}
      * @memberof User
      */
-    platformUserId?: string;
+    platformUserId?: string | null;
     /**
      * Your platform’s unique business ID for the user.
      * @type {string}
@@ -81,7 +81,7 @@ export interface User {
      */
     lastName?: string | null;
     /**
-     * The user’s roles. If no roles are defined, the user will be prompted to select a role within Kanmon. <br/><br/>A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. <br/><br/>An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. <br /><br/>Please note Kanmon supports an additional user role called secondary owners. Secondary owners are beneficial owners of a business, like primary owners, and Kanmon must perform KYC checks for these users. Kanmon will handle creating and managing these users for KYC purposes through a separate process. <br/>
+     * The user’s roles. <br/><br/>A primary owner is a user with the authority to issue debt on behalf of the business. This means the user can complete onboarding, receive offers, choose to accept offers, sign financing agreements, and service an active issued product. <br/><br/>An operator is a user with permission to service an active issued product. Examples are uploading invoices on behalf of the business, checking the status of payments, etc. <br /><br/>A secondary owner is a beneficial owner of the business who must complete KYC. This means the user can sign financing agreements when required and service an active issued product. During onboarding, the primary owner invites secondary owners. Secondary owners are directed to a separate Kanmon-hosted page where they complete onboarding, sign legal documents, and KYC. They can also access servicing from that page. Kanmon sends a `USER.CREATED` webhook when a secondary owner is created.
      * @type {Array<string>}
      * @memberof User
      */
@@ -118,7 +118,8 @@ export interface User {
  */
 export const UserRolesEnum = {
     PRIMARY_OWNER: 'PRIMARY_OWNER',
-    OPERATOR: 'OPERATOR'
+    OPERATOR: 'OPERATOR',
+    SECONDARY_OWNER: 'SECONDARY_OWNER'
 } as const;
 export type UserRolesEnum = typeof UserRolesEnum[keyof typeof UserRolesEnum];
 

--- a/ts/src/openapi/src/models/UserAlreadyExistsWithEmailException.ts
+++ b/ts/src/openapi/src/models/UserAlreadyExistsWithEmailException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/UserAlreadyExistsWithPlatformUserIdException.ts
+++ b/ts/src/openapi/src/models/UserAlreadyExistsWithPlatformUserIdException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/UserNotFoundException.ts
+++ b/ts/src/openapi/src/models/UserNotFoundException.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 

--- a/ts/src/openapi/src/models/index.ts
+++ b/ts/src/openapi/src/models/index.ts
@@ -120,6 +120,7 @@ export * from './PrimaryBusinessOwnerAlreadyExistsForBusinessException';
 export * from './PrimaryBusinessOwnerAlreadyExistsWithEmailException';
 export * from './PrimaryBusinessOwnerNotFoundException';
 export * from './ProductType';
+export * from './RepaymentCadence';
 export * from './SessionInvoice';
 export * from './SessionInvoiceWithInvoiceFile';
 export * from './SomeOffersHaveExpiredException';

--- a/ts/src/openapi/src/runtime.ts
+++ b/ts/src/openapi/src/runtime.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Kanmon Public V2 API
- * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms
+ * Kanmon\'s public api. Contains all of the endpoints for both capital providers and platforms.  ## Rate limiting  Endpoints in this API enforce a per-platform request quota. Responses include the following headers when a quota is in effect:  - `X-RateLimit-Limit` — maximum requests allowed per minute. - `X-RateLimit-Remaining` — requests remaining in the current window.  When the quota is exhausted the API responds with `429 Too Many Requests`. Platforms without a configured quota are unlimited and these headers are omitted.
  *
  * The version of the OpenAPI document: 2.0.0
  * 


### PR DESCRIPTION
Summary:
Update to latest APIs, fix JSON unknown field restriction, and upgrade SDK versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major version bump and new required draw/LOC fields can break deserialization or client assumptions; user listing behavior changes with secondary owners excluded by default unless `includeSecondaryOwners` is set.
> 
> **Overview**
> Regenerates the Java client from an updated **Kanmon Public V2** OpenAPI spec and bumps the Maven artifact from **3.2.2** to **4.0.0**.
> 
> **API surface documented and reflected in clients:** per-platform **rate limiting** (`429`, `X-RateLimit-Limit` / `X-RateLimit-Remaining`) across endpoints; **fetch users** gains optional `includeSecondaryOwners` (default excludes secondary owners). User models now document **`SECONDARY_OWNER`** in roles and treat `platformUserId` as nullable.
> 
> **Line-of-credit / draw repayment:** new **`RepaymentCadence`** (`WEEKLY` / `MONTHLY`), **`gracePeriodDays`**, **`numPaymentPeriods`**, and **`remainingBalanceCents`** on draw requests and related offer/servicing schemas; **`repaymentDurationMonths`** is marked deprecated in favor of cadence + period count.
> 
> **Other spec tweaks:** sandbox delete business documents **204**; generated test inventory swaps **`LoanStatusTest`** for **`SandboxUtilitiesApiTest`** and **`UsersApiTest`**.
> 
> Integrators should expect a **major SDK bump** and new required fields on some LOC/draw JSON payloads where the spec lists them as required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d4c3c750da79464ea6406441eaf04853660ce2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->