### PR TITLE
Fix Java SDK address NPE

### DIFF
--- a/java/api/openapi.yaml
+++ b/java/api/openapi.yaml
@@ -4367,7 +4367,6 @@ components:
           example: 2022-06-01T03:57:26.115Z
           type: string
       required:
-      - address
       - businessId
       - createdAt
       - email

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>kanmon-sdk</artifactId>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <url>https://github.com/Kanmon/sdk.git</url>
     <description>Kanmon API SDK</description>
     <scm>

--- a/java/src/main/java/com/kanmon/client/model/User.java
+++ b/java/src/main/java/com/kanmon/client/model/User.java
@@ -589,7 +589,6 @@ public class User {
     openapiRequiredFields.add("id");
     openapiRequiredFields.add("platformBusinessId");
     openapiRequiredFields.add("businessId");
-    openapiRequiredFields.add("address");
     openapiRequiredFields.add("email");
     openapiRequiredFields.add("metadata");
     openapiRequiredFields.add("createdAt");
@@ -631,8 +630,10 @@ public class User {
       if (!jsonObj.get("businessId").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `businessId` to be a primitive type in the JSON string but got `%s`", jsonObj.get("businessId").toString()));
       }
-      // validate the required field `address`
-      Address.validateJsonElement(jsonObj.get("address"));
+      // validate the optional field `address`
+      if (jsonObj.get("address") != null && !jsonObj.get("address").isJsonNull()) {
+        Address.validateJsonElement(jsonObj.get("address"));
+      }
       if ((jsonObj.get("email") != null && !jsonObj.get("email").isJsonNull()) && !jsonObj.get("email").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field `email` to be a primitive type in the JSON string but got `%s`", jsonObj.get("email").toString()));
       }

--- a/kanmon_api_spec.json
+++ b/kanmon_api_spec.json
@@ -4723,7 +4723,6 @@
           "id",
           "platformBusinessId",
           "businessId",
-          "address",
           "email",
           "metadata",
           "createdAt",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kanmon/sdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Kanmon API client",
   "author": "Kanmon",
   "repository": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow contract/SDK deserialization fix with no auth or data-path changes; consumers relying on address always being present may need to handle null.
> 
> **Overview**
> **User `address` is now optional** in the API spec and Java SDK, matching responses where address is omitted or null.
> 
> The OpenAPI/`kanmon_api_spec` **User** schema no longer lists `address` under `required`. In **`User.java`**, `address` is removed from required OpenAPI fields, and JSON validation only runs **`Address.validateJsonElement`** when `address` is present—avoiding an NPE that occurred when the field was missing.
> 
> SDK packages are bumped from **4.0.0** to **4.0.1** (`java/pom.xml`, `ts/package.json`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d60759b2880686067cf2d36f09792f85a78380be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->